### PR TITLE
cdep: remove Rancher warning

### DIFF
--- a/tools/cdep/commands/update_default.go
+++ b/tools/cdep/commands/update_default.go
@@ -73,23 +73,6 @@ var UpdateDefaultCmd = &cobra.Command{
 			return err
 		}
 
-		// TODO(gm): remove this when we move away from Rancher
-		if params.Type == "service" {
-			accept := []string{"y", "yes"}
-			var in string
-
-			fmt.Println("=== Warning ===")
-			fmt.Println("Running this on prod is not stable while we are using Rancher.")
-			fmt.Println("Are you sure you want to continue? (y/N)")
-			fmt.Printf("> ")
-			fmt.Scanln(&in)
-
-			if !slicecontains.String(accept, strings.ToLower(in)) {
-				fmt.Println("Thanks, come again soon. No changes.")
-				os.Exit(0)
-			}
-		}
-
 		return a.UpdateDefault(ctx, params, overruleChecks)
 	},
 }

--- a/tools/cdep/commands/update_default.go
+++ b/tools/cdep/commands/update_default.go
@@ -3,11 +3,9 @@ package commands
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/cuvva/cuvva-public-go/lib/cher"
-	"github.com/cuvva/cuvva-public-go/lib/slicecontains"
 	"github.com/cuvva/cuvva-public-go/tools/cdep"
 	"github.com/cuvva/cuvva-public-go/tools/cdep/app"
 	"github.com/cuvva/cuvva-public-go/tools/cdep/parsers"


### PR DESCRIPTION
It was never unstable on prod - just a problem on nonprod while it had several envs

Now we're running most envs on k8s, it's stable everywhere