### PR TITLE
jsonschema: add filesystem loader for use with embed

### DIFF
--- a/lib/jsonschema/filesystem.go
+++ b/lib/jsonschema/filesystem.go
@@ -1,0 +1,31 @@
+package jsonschema
+
+import (
+	"fmt"
+	"io/fs"
+	"io/ioutil"
+
+	"github.com/xeipuuv/gojsonschema"
+)
+
+type FS struct {
+	raw fs.FS
+}
+
+func NewFS(raw fs.FS) *FS {
+	return &FS{raw: raw}
+}
+
+func (f *FS) Load(filepath string) gojsonschema.JSONLoader {
+	file, err := f.raw.Open(fmt.Sprintf("%s.json", filepath))
+	if err != nil {
+		panic(fmt.Errorf("open json schema file: %w", err))
+	}
+
+	b, err := ioutil.ReadAll(file)
+	if err != nil {
+		panic(fmt.Errorf("read json schema file: %s", err))
+	}
+
+	return gojsonschema.NewBytesLoader(b)
+}

--- a/lib/jsonschema/filesystem.go
+++ b/lib/jsonschema/filesystem.go
@@ -12,12 +12,19 @@ type FS struct {
 	raw fs.FS
 }
 
+// NewFS will typically be passed an embed.FS to easily load separate .json schema files
 func NewFS(raw fs.FS) *FS {
 	return &FS{raw: raw}
 }
 
+// Loads the given filename suffixing with ".json"
+func (f *FS) LoadJSONExt(filepath string) gojsonschema.JSONLoader {
+	return f.Load(fmt.Sprintf("%s.json", filepath))
+}
+
+// Loads the given filename
 func (f *FS) Load(filepath string) gojsonschema.JSONLoader {
-	file, err := f.raw.Open(fmt.Sprintf("%s.json", filepath))
+	file, err := f.raw.Open(filepath)
 	if err != nil {
 		panic(fmt.Errorf("open json schema file: %w", err))
 	}


### PR DESCRIPTION
```
//go:embed *.json
var fs embed.FS
var schema = jsonschema.NewFS(fs).LoadJSONExt
...
zs.Register("view_subscriptions", "2019-11-03", schema("view_subscriptions"), rpc.ViewSubscriptions)
```