### PR TITLE
postcodesio: add interface guards

### DIFF
--- a/lib/postcodesio/client.go
+++ b/lib/postcodesio/client.go
@@ -115,3 +115,9 @@ func (fc *FailoverClient) ReverseGeocode(ctx context.Context, latitude, longitud
 		"longitude": longitude,
 	}, errors...)
 }
+
+// interface guards
+var (
+	_ Service = (*Client)(nil)
+	_ Service = (*FailoverClient)(nil)
+)

--- a/lib/postcodesio/client_test.go
+++ b/lib/postcodesio/client_test.go
@@ -8,20 +8,6 @@ import (
 	"github.com/cuvva/cuvva-public-go/lib/postcodesio"
 )
 
-// TestSvc checks if the client and fallback client conform to the same interface
-func TestSvc(t *testing.T) {
-	var client postcodesio.Service = &postcodesio.Client{}
-	var fallbackClient postcodesio.Service = &postcodesio.Client{}
-
-	if client == nil {
-		t.Error("postcodesio client does not conform to postcodes service interface")
-	}
-
-	if fallbackClient == nil {
-		t.Error("postcodesio fallback client does not conform to postcodes service interface")
-	}
-}
-
 // TestFallbackReverseGeocode tests if given two clients, the first of which
 // will error that it will retrieve a response
 func TestFallbackReverseGeocode(t *testing.T) {


### PR DESCRIPTION
As per ongoing conversations, this is not strictly needed but it will keep the `golangci-lint` quiet/happy.


more information: [https://caddyserver.com/docs/extending-caddy#interface-guards](https://caddyserver.com/docs/extending-caddy#interface-guards)