### PR TITLE
config: redis return client even on failed ping

### DIFF
--- a/lib/config/common.go
+++ b/lib/config/common.go
@@ -39,7 +39,7 @@ func (r Redis) Connect() (*redis.Client, error) {
 	client := redis.NewClient(opts)
 
 	if err := client.Ping().Err(); err != nil {
-		return nil, err
+		return client, err
 	}
 
 	return client, nil


### PR DESCRIPTION
this is so that apps which use redis as a cache can still use the connection pool to attempt to connect to redis later even if redis is down when they boot