### PR TITLE
jsonclient: fix gock version bump broken test matcher

### DIFF
--- a/lib/jsonclient/jsonclient_test.go
+++ b/lib/jsonclient/jsonclient_test.go
@@ -98,6 +98,7 @@ func TestRequestBody(t *testing.T) {
 
 	gock.New("http://coo.va/").
 		Post("/test").
+		MatchType("application/json; charset=utf-8").
 		JSON(testJSON).
 		Reply(http.StatusNoContent)
 


### PR DESCRIPTION
PR to fix broken test: gock version bump matches content-type header, and fails the test based on the charset we provide: `application/json; charset=utf-8` which it does not expect.