### PR TITLE
cdep: use ListContext instead of List to prevent/control context timeout

### DIFF
--- a/cmd/cdep/README.md
+++ b/cmd/cdep/README.md
@@ -71,3 +71,10 @@ You need an environment variable (`CUVVA_CODE_REPO`) with the location of where 
 Due to the tool doing a git fetch/pull/push, you need to have your SSH keys in your SSH Agent otherwise it won't know which to use to contact GitHub.
 
 You can see what identities are already linked by going into your shell and entering `ssh-add -l`. If none are there, you'll need to add them by entering `ssh-add`.
+
+### `context deadline exceeded`
+
+This error originates from the third party package we are using to list the references on the remote repository.
+We are currently hard coding the context timeout to 30 seconds and at the time of writing this duration seems to be
+working fine. However, if it takes longer in future (which shouldn't really happen) you can bump it in the
+[monorepo.go](tools/cdep/git/monorepo.go) file where `remote.ListContext` function is called.

--- a/tools/cdep/git/monorepo.go
+++ b/tools/cdep/git/monorepo.go
@@ -3,6 +3,7 @@ package git
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/cuvva/cuvva-public-go/lib/cher"
 	"github.com/cuvva/cuvva-public-go/tools/cdep/paths"
@@ -35,7 +36,10 @@ func GetLatestCommitHash(ctx context.Context, branchName string) (string, error)
 		}
 	}
 
-	refs, err := remote.List(&gogit.ListOptions{})
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	refs, err := remote.ListContext(ctx, &gogit.ListOptions{})
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This issue has been faced at two occasions. The issue still present so this piece of tweak solves it by increasing the context timeout and obviously controlling it ourselves within our code. The previous fix was directly in the third party repository however when looking at the `List` function closely it proxies the call to `ListContext` function by attaching a content with timeout. We are now calling `ListContext` with our context.
