### PR TITLE
run server with context and pre-allocated listener

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.mongodb.org/mongo-driver v1.7.3
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gopkg.in/h2non/gock.v1 v1.1.2
 	gopkg.in/intercom/intercom-go.v2 v2.0.0-20200217143803-6ffc0627261a
 )

--- a/lib/config/common.go
+++ b/lib/config/common.go
@@ -220,7 +220,7 @@ func (cfg *Server) Serve(ctx context.Context, l net.Listener, srv *http.Server) 
 		select {
 		case <-ctx.Done():
 			logrus.Println("shutting down gracefully")
-			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(cfg.Graceful)*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), cfg.GracefulTimeout())
 			defer cancel()
 			return srv.Shutdown(ctx)
 		case <-egCtx.Done():
@@ -229,6 +229,14 @@ func (cfg *Server) Serve(ctx context.Context, l net.Listener, srv *http.Server) 
 	})
 
 	return eg.Wait()
+}
+
+func (cfg *Server) GracefulTimeout() time.Duration {
+	if cfg.Graceful == 0 {
+		cfg.Graceful = DefaultGraceful
+	}
+
+	return time.Duration(cfg.Graceful) * time.Second
 }
 
 func ContextWithCancelOnSignal(ctx context.Context) context.Context {

--- a/lib/config/common.go
+++ b/lib/config/common.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"errors"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -14,9 +15,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/cuvva/cuvva-public-go/lib/db/mongodb"
 	"github.com/go-redis/redis"
+	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
+	"golang.org/x/sync/errgroup"
 )
 
 // Redis configures a connection to a Redis database.
@@ -163,7 +166,7 @@ func (cfg *Server) ListenAndServe(srv *http.Server) error {
 	}
 
 	stop := make(chan os.Signal, 1)
-	signal.Notify(stop, syscall.SIGTERM)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 
 	errs := make(chan error, 1)
 
@@ -188,6 +191,59 @@ func (cfg *Server) ListenAndServe(srv *http.Server) error {
 
 		return nil
 	}
+}
+
+func (cfg *Server) Listen() (net.Listener, error) {
+	l, err := net.Listen("tcp", cfg.Addr)
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.WithField("addr", cfg.Addr).Info("listening")
+	return l, nil
+}
+
+// Serve the HTTP requests on the specified listener, and gracefully close when the context is cancelled.
+func (cfg *Server) Serve(ctx context.Context, l net.Listener, srv *http.Server) (err error) {
+	eg, egCtx := errgroup.WithContext(ctx)
+
+	eg.Go(func() error {
+		err := srv.Serve(l)
+		if err == http.ErrServerClosed {
+			return nil
+		}
+
+		return err
+	})
+
+	eg.Go(func() error {
+		select {
+		case <-ctx.Done():
+			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(cfg.Graceful)*time.Second)
+			defer cancel()
+			return srv.Shutdown(ctx)
+		case <-egCtx.Done():
+			return nil
+		}
+	})
+
+	return eg.Wait()
+}
+
+func ContextWithCancelOnSignal(ctx context.Context) context.Context {
+	ctx, cancel := context.WithCancel(ctx)
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
+
+	go func() {
+		defer cancel()
+		select {
+		case <-stop:
+		case <-ctx.Done():
+		}
+	}()
+
+	return ctx
 }
 
 // UnderwriterOpts represents the underwriters info/models options.

--- a/lib/config/common.go
+++ b/lib/config/common.go
@@ -219,6 +219,7 @@ func (cfg *Server) Serve(ctx context.Context, l net.Listener, srv *http.Server) 
 	eg.Go(func() error {
 		select {
 		case <-ctx.Done():
+			logrus.Println("shutting down gracefully")
 			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(cfg.Graceful)*time.Second)
 			defer cancel()
 			return srv.Shutdown(ctx)


### PR DESCRIPTION
allow pre-allocating a listener before running the server
- can bootstrap separately from running meaning it takes less time to attach the handler to the socket
- socket already being open means tests can connect to the socket to send http requests while the handler hasn't been attached in a separate go routine
- basically means no time.Sleep() in acceptance/system/functional tests

run with context:
- when running the app in integration tests, this allows us to shut the app down (we couldn't do this before)

listen on other signals:
- it wasn't shutting down gracefully when I used ctrl+c, it was only coded for k8s

cleaner code:
- acquire a context with signal termination separately
- use errgroup instead of the same thing but messier with err channel ourselves

other things to think about:
- our graceful termination is currently only 5 seconds, this could be something that is causing context timeouts in production, I would suggest raising it to 65 seconds

TODO:
- remove old code config.Server.ListenAndServe() when services have migrated to the new approach https://github.com/cuvva/cuvva-public-go/blob/master/lib/config/common.go#L155