### PR TITLE
checkmot: merge results when multiple identical vehicles

### DIFF
--- a/lib/checkmot/checkmot.go
+++ b/lib/checkmot/checkmot.go
@@ -1,6 +1,7 @@
 package checkmot
 
-const ErrUnexpectedResultCount = "unexpected number of results"
+const ErrNoResults = "no results"
+const ErrMultipleVehicles = "multiple vehicles returned"
 
 type Vehicle struct {
 	Registration  string `json:"registration"`

--- a/lib/checkmot/checkmot.go
+++ b/lib/checkmot/checkmot.go
@@ -1,7 +1,11 @@
 package checkmot
 
-const ErrNoResults = "no results"
-const ErrMultipleVehicles = "multiple vehicles returned"
+import "errors"
+
+var (
+	ErrNoResults        = errors.New("no results")
+	ErrMultipleVehicles = errors.New("multiple vehicles returned")
+)
 
 type Vehicle struct {
 	Registration  string `json:"registration"`

--- a/lib/checkmot/client.go
+++ b/lib/checkmot/client.go
@@ -2,7 +2,6 @@ package checkmot
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"net/url"
 	"time"
@@ -33,7 +32,7 @@ func (c *Client) GetRecordByVRM(ctx context.Context, vrm string) (res *Vehicle, 
 	}
 
 	if len(out) == 0 {
-		return nil, errors.New(ErrNoResults)
+		return nil, ErrNoResults
 	}
 
 	if len(out) == 1 {
@@ -48,7 +47,7 @@ func (c *Client) GetRecordByVRM(ctx context.Context, vrm string) (res *Vehicle, 
 func attemptToMergeTestsForTheSameVehicle(out []*Vehicle) (*Vehicle, error) {
 	for i := 1; i < len(out); i++ {
 		if !isSameVehicle(out[0], out[i]) {
-			return nil, errors.New(ErrMultipleVehicles)
+			return nil, ErrMultipleVehicles
 		}
 
 		out[0].MOTTests = append(out[0].MOTTests, out[i].MOTTests...)
@@ -73,6 +72,24 @@ func isSameVehicle(a *Vehicle, b *Vehicle) bool {
 	if a.PrimaryColour != b.PrimaryColour {
 		return false
 	}
+	if !stringPointerCompare(a.ManufactureYear, b.ManufactureYear) {
+		return false
+	}
+	if !stringPointerCompare((*string)(a.FirstUsedDate), (*string)(b.FirstUsedDate)) {
+		return false
+	}
 
 	return true
+}
+
+func stringPointerCompare(a, b *string) bool {
+	if a == nil {
+		return b == nil
+	}
+
+	if b == nil {
+		return false
+	}
+
+	return *a == *b
 }

--- a/lib/checkmot/client.go
+++ b/lib/checkmot/client.go
@@ -32,9 +32,47 @@ func (c *Client) GetRecordByVRM(ctx context.Context, vrm string) (res *Vehicle, 
 		return
 	}
 
-	if len(out) != 1 {
-		return nil, errors.New(ErrUnexpectedResultCount)
+	if len(out) == 0 {
+		return nil, errors.New(ErrNoResults)
+	}
+
+	if len(out) == 1 {
+		return out[0], nil
+	}
+
+	return attemptToMergeTestsForTheSameVehicle(out)
+}
+
+// the API sometimes returns multiple vehicles with the same details even for a specific vehicle search
+// merge the list of MOT tests if all vehicle details are the same
+func attemptToMergeTestsForTheSameVehicle(out []*Vehicle) (*Vehicle, error) {
+	for i := 1; i < len(out); i++ {
+		if !isSameVehicle(out[0], out[i]) {
+			return nil, errors.New(ErrMultipleVehicles)
+		}
+
+		out[0].MOTTests = append(out[0].MOTTests, out[i].MOTTests...)
 	}
 
 	return out[0], nil
+}
+
+func isSameVehicle(a *Vehicle, b *Vehicle) bool {
+	if a.Make != b.Make {
+		return false
+	}
+	if a.Model != b.Model {
+		return false
+	}
+	if a.Registration != b.Registration {
+		return false
+	}
+	if a.FuelType != b.FuelType {
+		return false
+	}
+	if a.PrimaryColour != b.PrimaryColour {
+		return false
+	}
+
+	return true
 }

--- a/lib/checkmot/client_test.go
+++ b/lib/checkmot/client_test.go
@@ -1,0 +1,148 @@
+package checkmot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient_GetRecordByVRM(t *testing.T) {
+	type testCase struct {
+		name           string
+		response       []byte
+		expectedResult *Vehicle
+		expectedErr    error
+	}
+
+	tests := []testCase{
+		{
+			name: "",
+			response: []byte(`
+[
+  {
+    "registration": "CUV 001",
+    "make": "BMW",
+    "model": "X3",
+    "firstUsedDate": "2007.10.02",
+    "fuelType": "Diesel",
+    "primaryColour": "Grey",
+    "motTests": [
+      {
+        "completedDate": "2017.08.15 12:47:50",
+        "testResult": "PASSED",
+        "expiryDate": "2018.08.23",
+        "odometerValue": "114722",
+        "odometerUnit": "mi",
+        "motTestNumber": "269281492742",
+        "odometerResultType": "READ",
+        "rfrAndComments": [
+          {
+            "text": "Nearside Rear Tyre worn close to the legal limit (4.1.E.1)",
+            "type": "ADVISORY",
+            "dangerous": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "registration": "CUV 001",
+    "make": "BMW",
+    "model": "X3",
+    "firstUsedDate": "2007.10.02",
+    "fuelType": "Diesel",
+    "primaryColour": "Grey",
+    "motTests": [
+      {
+        "completedDate": "2021.09.24 12:07:40",
+        "testResult": "PASSED",
+        "expiryDate": "2022.09.23",
+        "odometerValue": "162236",
+        "odometerUnit": "mi",
+        "motTestNumber": "752024886501",
+        "odometerResultType": "READ",
+        "rfrAndComments": [
+          {
+            "text": "Offside Registration plate lamp inoperative in the case of multiple lamps or light sources (4.7.1 (b) (i))",
+            "type": "MINOR",
+            "dangerous": false
+          }
+        ]
+      }
+    ]
+  }
+]
+`),
+			expectedResult: &Vehicle{
+				Registration:    "CUV 001",
+				Make:            "BMW",
+				Model:           "X3",
+				FuelType:        "Diesel",
+				PrimaryColour:   "Grey",
+				ManufactureYear: nil,
+				DVLAID:          nil,
+				MOTTestDueDate:  nil,
+				FirstUsedDate:   datePtr("2007-10-02"),
+				MOTTests: []*MOTTest{
+					{
+
+						CompletedDate:      Time{time.Date(2017, 8, 15, 12, 47, 50, 0, loc)},
+						TestResult:         "PASSED",
+						ExpiryDate:         datePtr("2018-08-23"),
+						OdometerValue:      "114722",
+						OdometerUnit:       "mi",
+						MOTTestNumber:      "269281492742",
+						OdometerResultType: "READ",
+						RfRAndComments: []*RfROrComment{
+							{
+								Text:      "Nearside Rear Tyre worn close to the legal limit (4.1.E.1)",
+								Type:      "ADVISORY",
+								Dangerous: false,
+							},
+						},
+					},
+					{
+
+						CompletedDate:      Time{time.Date(2021, 9, 24, 12, 7, 40, 0, loc)},
+						TestResult:         "PASSED",
+						ExpiryDate:         datePtr("2022-09-23"),
+						OdometerValue:      "162236",
+						OdometerUnit:       "mi",
+						MOTTestNumber:      "752024886501",
+						OdometerResultType: "READ",
+						RfRAndComments: []*RfROrComment{
+							{
+								Text:      "Offside Registration plate lamp inoperative in the case of multiple lamps or light sources (4.7.1 (b) (i))",
+								Type:      "MINOR",
+								Dangerous: false,
+							},
+						},
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write(tc.response)
+			}))
+
+			client := NewClient(srv.URL, "client-key")
+			res, err := client.GetRecordByVRM(context.Background(), "CUV 001")
+			assert.Equal(t, tc.expectedResult, res)
+			assert.Equal(t, tc.expectedErr, err)
+		})
+	}
+}
+
+func datePtr(str string) *Date {
+	d := Date(str)
+	return &d
+}

--- a/lib/checkmot/client_test.go
+++ b/lib/checkmot/client_test.go
@@ -20,7 +20,13 @@ func TestClient_GetRecordByVRM(t *testing.T) {
 
 	tests := []testCase{
 		{
-			name: "",
+			name:           "no results",
+			response:       []byte(`[]`),
+			expectedResult: nil,
+			expectedErr:    ErrNoResults,
+		},
+		{
+			name: "two results same vehicle",
 			response: []byte(`
 [
   {
@@ -125,6 +131,66 @@ func TestClient_GetRecordByVRM(t *testing.T) {
 				},
 			},
 			expectedErr: nil,
+		},
+		{
+			name: "multiple results different vehicles",
+			response: []byte(`
+[
+  {
+    "registration": "CUV 001",
+    "make": "BMW",
+    "model": "X3",
+    "firstUsedDate": "2007.10.02",
+    "fuelType": "Diesel",
+    "primaryColour": "Grey",
+    "motTests": [
+      {
+        "completedDate": "2017.08.15 12:47:50",
+        "testResult": "PASSED",
+        "expiryDate": "2018.08.23",
+        "odometerValue": "114722",
+        "odometerUnit": "mi",
+        "motTestNumber": "269281492742",
+        "odometerResultType": "READ",
+        "rfrAndComments": [
+          {
+            "text": "Nearside Rear Tyre worn close to the legal limit (4.1.E.1)",
+            "type": "ADVISORY",
+            "dangerous": false
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "registration": "CUV 001",
+    "make": "BMW",
+    "model": "X3",
+    "firstUsedDate": "2011.10.02",
+    "fuelType": "Diesel",
+    "primaryColour": "Grey",
+    "motTests": [
+      {
+        "completedDate": "2021.09.24 12:07:40",
+        "testResult": "PASSED",
+        "expiryDate": "2022.09.23",
+        "odometerValue": "162236",
+        "odometerUnit": "mi",
+        "motTestNumber": "752024886501",
+        "odometerResultType": "READ",
+        "rfrAndComments": [
+          {
+            "text": "Offside Registration plate lamp inoperative in the case of multiple lamps or light sources (4.7.1 (b) (i))",
+            "type": "MINOR",
+            "dangerous": false
+          }
+        ]
+      }
+    ]
+  }
+]`),
+			expectedResult: nil,
+			expectedErr:    ErrMultipleVehicles,
 		},
 	}
 


### PR DESCRIPTION
Some VRMs return multiple vehicle objects with different lists of MOT tests but all vehicle information is the same, in these cases merge the MOT test lists and return a single result.

I have opened a ticket with the external API support team regarding this undocumented response scenarios.