### PR TITLE
checkmot: avoid network connection reset

### DIFF
--- a/lib/checkmot/roundtripper.go
+++ b/lib/checkmot/roundtripper.go
@@ -5,12 +5,13 @@ import (
 )
 
 type roundTripper struct {
-	apiKey string
+	apiKey    string
+	transport http.RoundTripper
 }
 
 func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Set("Accept", "application/json+v4")
 	req.Header.Set("X-Api-Key", rt.apiKey)
 
-	return http.DefaultTransport.RoundTrip(req)
+	return rt.transport.RoundTrip(req)
 }


### PR DESCRIPTION
you can use the command to see what the idle timeout is on your connection server side: 
```
time openssl s_client -connect beta.check-mot.service.gov.uk:443
```

The default go client idle timeout is 90 seconds, and the server will not let us use keepalives to keep the connection alive for longer than 60 seconds. 

So currently we see this error when we try to re-use an idle connection that we think should still work:
```
GET /trade/vehicles/mot-tests request failed: Get "https://beta.check-mot.service.gov.uk/trade/vehicles/mot-tests?registration=CUV001": read tcp 10.8.223.4:41318->45.60.65.113:443: read: connection reset by peer
```

- **You must have a lower idle timeout on the client that on the server to avoid connection resets when the connection is attempted to be used**
- also reduced the max number of connections to their host to 3 per service pod. So we can have 9 connections open to them in total on prod, since we hit rate limits it might help 🤷 