### PR TITLE
context-based use for `servicecontext`

### DIFF
--- a/lib/clog/clog.go
+++ b/lib/clog/clog.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cuvva/cuvva-public-go/lib/cher"
 	"github.com/cuvva/cuvva-public-go/lib/servicecontext"
+	"github.com/cuvva/cuvva-public-go/lib/version"
 	"github.com/sirupsen/logrus"
 )
 
@@ -54,7 +55,7 @@ type Config struct {
 func (c Config) Configure() (log *logrus.Entry) {
 	log = logrus.WithFields(logrus.Fields{
 		ServiceKey: servicecontext.Get().Name,
-		VersionKey: servicecontext.Get().Revision,
+		VersionKey: version.Revision,
 	})
 
 	hostname, err := os.Hostname()

--- a/lib/crpc/client.go
+++ b/lib/crpc/client.go
@@ -27,7 +27,7 @@ func NewClient(baseURL string, c *http.Client) *Client {
 
 	if servicecontext.IsSet() {
 		svc := servicecontext.Get()
-		jcc.UserAgent = fmt.Sprintf(userAgentTemplateWithService, svc.Version, svc.Name, svc.Environment)
+		jcc.UserAgent = fmt.Sprintf(userAgentTemplateWithService, version.Truncated, svc.Name, svc.Environment)
 	} else {
 		jcc.UserAgent = fmt.Sprintf(userAgentTemplate, version.Truncated)
 	}

--- a/lib/servicecontext/servicecontext.go
+++ b/lib/servicecontext/servicecontext.go
@@ -1,15 +1,9 @@
 package servicecontext
 
-import (
-	"github.com/cuvva/cuvva-public-go/lib/version"
-)
-
 // Info type holds useful info about the currently-running service
 type Info struct {
 	Name        string
 	Environment string
-	Version     string
-	Revision    string
 }
 
 var service *Info
@@ -19,8 +13,6 @@ func Set(name, env string) {
 	service = &Info{
 		Name:        name,
 		Environment: env,
-		Version:     version.Truncated,
-		Revision:    version.Revision,
 	}
 }
 

--- a/lib/servicecontext/servicecontext.go
+++ b/lib/servicecontext/servicecontext.go
@@ -1,5 +1,9 @@
 package servicecontext
 
+import (
+	"context"
+)
+
 // Info type holds useful info about the currently-running service
 type Info struct {
 	Name        string
@@ -28,4 +32,27 @@ func Get() Info {
 // IsSet returns true if the singleton has been initialised
 func IsSet() bool {
 	return service != nil
+}
+
+type contextKey string
+
+var (
+	infoContextKey = contextKey("info")
+)
+
+// SetContext wraps the context with the service info
+func SetContext(ctx context.Context, name, env string) context.Context {
+	return context.WithValue(ctx, infoContextKey, &Info{
+		Name:        name,
+		Environment: env,
+	})
+}
+
+// GetContext retrieves the service info from the context
+func GetContext(ctx context.Context) *Info {
+	if val, ok := ctx.Value(infoContextKey).(*Info); ok {
+		return val
+	}
+
+	return nil
 }


### PR DESCRIPTION
I'm pretty confident that the two values copied from `version` have never been used in any codebase. They will always be the same as the values in `version`, because this library offers no way to override them. Can undo this bit if you want though

I would recommend deprecating & removing the older servicecontext methods - they're quite inflexible and prevent running multiple services in the same runtime