### PR TITLE
cher: add WrapIfNotCher func

### DIFF
--- a/lib/cher/error.go
+++ b/lib/cher/error.go
@@ -152,3 +152,16 @@ func Coerce(v interface{}) E {
 func (e E) Value() (driver.Value, error) {
 	return json.Marshal(e)
 }
+
+func WrapIfNotCher(err error, msg string) error {
+	if err == nil {
+		return nil
+	}
+
+	var cErr E
+	if errors.As(err, &cErr) {
+		return cErr
+	}
+
+	return errors.Wrap(err, msg)
+}


### PR DESCRIPTION
sometimes we call other internal services
- if they return a cher we usually want to just pass that along
- if they return an error we want to wrap it so we get the context required to know what failed

another approach could be in our http response handler to check if the requests error has any cher wrapped in it anywhere, but the problem is that would affect all our codebase and so is much riskier.