### PR TITLE
config: configurable mongo connect timeout for tests

### DIFF
--- a/lib/config/common.go
+++ b/lib/config/common.go
@@ -62,7 +62,8 @@ func (r Redis) Connect() (*redis.Client, error) {
 
 // MongoDB configures a connection to a Mongo database.
 type MongoDB struct {
-	URI string `json:"uri"`
+	URI            string        `json:"uri"`
+	ConnectTimeout time.Duration `json:"connect_timeout"`
 }
 
 // Options returns the MongoDB client options and database name.
@@ -97,9 +98,13 @@ func (m MongoDB) Connect() (*mongodb.Database, error) {
 		return nil, err
 	}
 
+	if m.ConnectTimeout == 0 {
+		m.ConnectTimeout = 10 * time.Second
+	}
+
 	// this package can only be used for service config
 	// so can only happen at init-time - no need to accept context input
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), m.ConnectTimeout)
 	defer cancel()
 
 	return mongodb.Connect(ctx, opts, dbName)


### PR DESCRIPTION
mongo lib actually has a connect timeout options, but we use our own context timeout anyhow.

the whole config package here really makes it hard to customise or configure anything, its like a big wall put in front of a useful package.

this is the least invasive way to allow me to timeout integration tests which need to connect to mongo. I intend to skip tests with a message "unable to connect to mongo" to allow engineers to run the test suite while not having database services available. Therefore showing skip messages instead of errors.

waiting 10 seconds for those tests to skip is unreasonable, so we need to configure the timeout.