### PR TITLE
soap: add xml tag to the Content field of header and body

### DIFF
--- a/lib/soap/soap.go
+++ b/lib/soap/soap.go
@@ -14,7 +14,7 @@ type Envelope struct {
 type Header struct {
 	XMLName xml.Name `json:"-" xml:"http://schemas.xmlsoap.org/soap/envelope/ Header"`
 
-	Content interface{}
+	Content interface{} `xml:",any"`
 }
 
 type Body struct {
@@ -22,7 +22,7 @@ type Body struct {
 
 	Fault *Fault
 
-	Content interface{}
+	Content interface{} `xml:",any"`
 }
 
 type Fault struct {


### PR DESCRIPTION
The decoder wasn't decoding the interface value properly without this tag

According to the Go [docs](https://pkg.go.dev/encoding/xml#Unmarshal):
>If the XML element contains a sub-element that hasn't matched any
   of the above rules and the struct has a field with tag ",any",
   unmarshal maps the sub-element to that struct field.

Example of the issue: https://go.dev/play/p/sZTC4jwaXQb