### PR TITLE
mongodb: use majority read-concern

### DIFF
--- a/lib/config/common.go
+++ b/lib/config/common.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-redis/redis"
 	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readconcern"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
 	"golang.org/x/sync/errgroup"
@@ -74,9 +75,10 @@ func (m MongoDB) Options() (opts *options.ClientOptions, dbName string, err erro
 		return
 	}
 
-	// all Go services use majority writes, and this is unlikely to change
+	// all Go services use majority reads/writes, and this is unlikely to change
 	// if it does change, switch to accepting as an argument
-	opts.WriteConcern = writeconcern.New(writeconcern.WMajority())
+	opts.SetReadConcern(readconcern.Majority())
+	opts.SetWriteConcern(writeconcern.New(writeconcern.WMajority()))
 
 	cs, err := connstring.Parse(m.URI)
 	if err != nil {


### PR DESCRIPTION
By default (and as it stands in this library), MongoDB uses the `local` read concern. The documentation states:

> The query returns data from the instance with no guarantee that the data has been written to a majority of the replica set members (i.e. may be rolled back).

Given this library enforces majority writes, and read-after-write consistency is pretty important, I think it should also enforce majority reads. Then data becomes visible at the same point where it's considered to have been written successfully.

The documentation also highlights that performance is comparable to other read concerns, so this benefit comes without any caveats/downsides/tradeoffs:

> To fulfill read concern "majority", the replica set member returns data from its in-memory view of the data at the majority-commit point. As such, read concern "majority" is comparable in performance cost to other read concerns.

Ultimately, although Mongo now does offer excellent consistency and ACID compliance, these guarantees are only made when using both majority read and write concerns.

Relevant info:

- https://docs.mongodb.com/manual/reference/read-concern/
- https://vkontech.com/causal-consistency-guarantees-in-mongodb-majority-read-and-write-concerns/
- https://jepsen.io/analyses/mongodb-3-6-4