### PR TITLE
cher: WrapIfNotCherCodes

### DIFF
--- a/lib/cher/error.go
+++ b/lib/cher/error.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/cuvva/cuvva-public-go/lib/slicecontains"
 	"github.com/pkg/errors"
 )
 
@@ -153,6 +154,9 @@ func (e E) Value() (driver.Value, error) {
 	return json.Marshal(e)
 }
 
+// WrapIfNotCher will not wrap the error if it is any cher except unknown.
+//
+// Unless you don't know the codes you could get back, you should use WrapIfNotCherCodes.
 func WrapIfNotCher(err error, msg string) error {
 	if err == nil {
 		return nil
@@ -160,6 +164,24 @@ func WrapIfNotCher(err error, msg string) error {
 
 	var cErr E
 	if errors.As(err, &cErr) {
+		if cErr.Code == Unknown {
+			return errors.Wrap(err, msg)
+		}
+
+		return cErr
+	}
+
+	return errors.Wrap(err, msg)
+}
+
+// WrapIfNotCherCodes will wrap an error unless it is a cher with specific codes.
+func WrapIfNotCherCodes(err error, msg string, codes []string) error {
+	if err == nil {
+		return nil
+	}
+
+	var cErr E
+	if errors.As(err, &cErr) && slicecontains.String(codes, cErr.Code) {
 		return cErr
 	}
 

--- a/lib/cher/error_test.go
+++ b/lib/cher/error_test.go
@@ -122,6 +122,72 @@ func TestWrapIfNotCher(t *testing.T) {
 				assert.Equal(t, "nope", cErr.Code)
 			},
 		},
+		{
+			name: "cher unknown",
+			msg:  "foo",
+			err:  New("unknown", nil),
+			expect: func(t *testing.T, err error) {
+				assert.EqualError(t, err, "foo: unknown")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := WrapIfNotCher(tc.err, tc.msg)
+			tc.expect(t, result)
+		})
+	}
+}
+
+func TestWrapIfNotCherCodes(t *testing.T) {
+	type testCase struct {
+		name   string
+		msg    string
+		codes  []string
+		err    error
+		expect func(*testing.T, error)
+	}
+
+	tests := []testCase{
+		{
+			name:  "nil",
+			msg:   "foo",
+			codes: []string{"code_1"},
+			err:   nil,
+			expect: func(t *testing.T, err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name:  "err",
+			msg:   "foo",
+			codes: []string{"code_1"},
+			err:   fmt.Errorf("nope"),
+			expect: func(t *testing.T, err error) {
+				assert.EqualError(t, err, "foo: nope")
+			},
+		},
+		{
+			name:  "cher specified code",
+			msg:   "foo",
+			codes: []string{"code_1"},
+			err:   New("code_1", nil),
+			expect: func(t *testing.T, err error) {
+				cErr, ok := err.(E)
+				assert.True(t, ok)
+				assert.Equal(t, "code_1", cErr.Code)
+			},
+		},
+		{
+			name:  "cher other code",
+			msg:   "foo",
+			codes: []string{"unknown"},
+			err:   New("unknown", nil),
+			expect: func(t *testing.T, err error) {
+				assert.EqualError(t, err, "foo: unknown")
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
unknown errors not being wrapped means you have no idea about anything 😂 

preferably it wouldn't be possible to have a cher code "unknown" since it can't be a "handled error"

but that is a probably a bit too much to unpick, so wrap "unknown" codes instead.