### PR TITLE
crpc: broken pipe on response write is ok

### DIFF
--- a/lib/crpc/server.go
+++ b/lib/crpc/server.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
+	"strings"
 
 	"github.com/cuvva/cuvva-public-go/lib/cher"
 	"github.com/xeipuuv/gojsonschema"
@@ -184,6 +185,10 @@ func Wrap(fn interface{}) (*WrappedFunc, error) {
 			enc.SetEscapeHTML(false)
 			err := enc.Encode(res[0].Interface())
 			if err != nil {
+				if strings.Contains(err.Error(), "broken pipe") {
+					return nil
+				}
+
 				return err
 			}
 		}


### PR DESCRIPTION
this is an attempt to reduce error log noise.

if we try to write the response to the client and they have closed the connection, this isn't an error that we can do anything about, so don't return an error.

it is hard to test this, locally if I cancel my http request when paused before the response writing, I don't get an error when it writes, but perhaps you need to have a TCP router in between the client and server which has closed the connection.