### PR TITLE
oncallcalc: uses new pagerduty function with context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.1.1 // indirect
+	github.com/jackc/pgproto3/v2 v2.3.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/tools/oncallcalc/app/list_pd_shifts.go
+++ b/tools/oncallcalc/app/list_pd_shifts.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -18,7 +19,8 @@ type PDShift struct {
 func (a *App) ListPagerDutyShifts(scheduleID string, start, end time.Time) ([]*PDShift, interface{}, error) {
 	var shifts []*PDShift
 
-	res, err := a.pagerduty.ListOnCalls(pagerduty.ListOnCallOptions{
+	// @TODO context should be injected from the cobra entry point
+	res, err := a.pagerduty.ListOnCallsWithContext(context.Background(), pagerduty.ListOnCallOptions{
 		Includes:    []string{"users"},
 		ScheduleIDs: []string{scheduleID},
 		Since:       start.Format(time.RFC3339),


### PR DESCRIPTION
## Context

- we've been using deprecated endpoint from the pargerduty library
- ideally we'll need more iteration to pass the context through from the cobra command