### PR TITLE
linting: use proper err, upgrade linting, fix deprecated method

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Run lint and report
         uses: reviewdog/action-golangci-lint@v2.1
         env:
-          GOLANGCI_LINT_VERSION: "v1.28"
+          GOLANGCI_LINT_VERSION: "v1.46.0"
         with:
           github_token: ${{ secrets.github_token }}
           tool_name: "GolangCI Linter"

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.mongodb.org/mongo-driver v1.9.1
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/text v0.3.7
 	gopkg.in/h2non/gock.v1 v1.1.2
 	gopkg.in/intercom/intercom-go.v2 v2.0.0-20200217143803-6ffc0627261a
 )
@@ -81,7 +82,6 @@ require (
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
-	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/lib/dln/dln.go
+++ b/lib/dln/dln.go
@@ -6,6 +6,9 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 var ErrInvalidInput = errors.New("invalid input")
@@ -119,7 +122,7 @@ func generateSectionC(personalName string, includeMiddleName bool) string {
 }
 
 func parseSectionA(a string) string {
-	familyName := strings.Title(strings.ToLower(a))
+	familyName := cases.Title(language.BritishEnglish).String(strings.ToLower(a))
 
 	return strings.Replace(familyName, "9", "", 4)
 }

--- a/lib/middleware/request/json_error.go
+++ b/lib/middleware/request/json_error.go
@@ -14,8 +14,8 @@ func JSONError(w http.ResponseWriter, err error) {
 
 	e := json.NewEncoder(w)
 
-	if err, ok := err.(cher.E); ok {
-		e.Encode(err)
+	if chErr, ok := err.(cher.E); ok {
+		e.Encode(chErr)
 	} else {
 		e.Encode(cher.New(cher.Unauthorized, nil, cher.New(cher.Unknown, cher.M{"error": err})))
 	}


### PR DESCRIPTION
## Context

- we recently upgraded to go 1.18 but did not upgrade our linter to latest

- fix deprecated usage of `strings.Title()` in favour of `cases.Title()`
- fix wrong usage of `err` when attempting to cast it