### PR TITLE
clog: info level postgres context cancelled logs

### DIFF
--- a/lib/clog/clog.go
+++ b/lib/clog/clog.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
 
 	"github.com/cuvva/cuvva-public-go/lib/cher"
 	"github.com/cuvva/cuvva-public-go/lib/servicecontext"
@@ -248,6 +249,13 @@ func DetermineLevel(err error, timeoutsAsErrors bool) logrus.Level {
 		default:
 			return logrus.WarnLevel
 		}
+	}
+
+	if strings.Contains(err.Error(), "canceling statement due to user request") {
+		if timeoutsAsErrors {
+			return logrus.ErrorLevel
+		}
+		return logrus.InfoLevel
 	}
 
 	// non-cher errors are "unhandled" so warrant an error

--- a/lib/clog/clog_test.go
+++ b/lib/clog/clog_test.go
@@ -3,9 +3,11 @@ package clog
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
+	"github.com/cuvva/cuvva-public-go/lib/cher"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
@@ -102,4 +104,65 @@ func TestContextLogger(t *testing.T) {
 		assert.Equal(t, "no clog exists in the context", err.Error())
 	})
 
+}
+
+func TestDetermineLevel(t *testing.T) {
+	type testCase struct {
+		name             string
+		err              error
+		timeoutsAsErrors bool
+		expected         logrus.Level
+	}
+
+	tests := []testCase{
+		{
+			name:             "bad request",
+			err:              cher.New("bad_request", nil),
+			timeoutsAsErrors: false,
+			expected:         logrus.WarnLevel,
+		},
+		{
+			name:             "context cancelled",
+			err:              cher.New(cher.ContextCanceled, nil),
+			timeoutsAsErrors: false,
+			expected:         logrus.InfoLevel,
+		},
+		{
+			name:             "context cancelled with timeouts as errors",
+			err:              cher.New(cher.ContextCanceled, nil),
+			timeoutsAsErrors: true,
+			expected:         logrus.ErrorLevel,
+		},
+		{
+			name:             "unknown",
+			err:              cher.New(cher.Unknown, nil),
+			timeoutsAsErrors: false,
+			expected:         logrus.ErrorLevel,
+		},
+		{
+			name:             "postgres context cancelled",
+			err:              fmt.Errorf("pq: canceling statement due to user request"),
+			timeoutsAsErrors: false,
+			expected:         logrus.InfoLevel,
+		},
+		{
+			name:             "postgres context cancelled with timeouts as errors",
+			err:              fmt.Errorf("pq: canceling statement due to user request"),
+			timeoutsAsErrors: true,
+			expected:         logrus.ErrorLevel,
+		},
+		{
+			name:             "other error",
+			err:              fmt.Errorf("something something darkside"),
+			timeoutsAsErrors: false,
+			expected:         logrus.ErrorLevel,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := DetermineLevel(tc.err, tc.timeoutsAsErrors)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
 }


### PR DESCRIPTION
this will stop errors logs showing up when the apps cancel a request because the user changes screen, making it behave the same as normal context cancelled errors in golang.

this is because the postgres library we use has a weird error custom error for context cancelled.