### PR TITLE
remove listening log

### DIFF
--- a/lib/config/common.go
+++ b/lib/config/common.go
@@ -206,7 +206,6 @@ func (cfg *Server) Listen() (net.Listener, error) {
 		return nil, err
 	}
 
-	logrus.WithField("addr", cfg.Addr).Info("listening")
 	return l, nil
 }
 


### PR DESCRIPTION
this function is only used by two services at the moment to be able to allocate a http port before booting the whole app, this feature allows us to easily boot the app for testing on ephemeral ports.

rather than have this code understand logging, and therefore having to globally configure a logger or pass a logger in, we should instead log in the caller of this function.