### PR TITLE
clog: info level logs on cancelled pgx pool connect

### DIFF
--- a/lib/cher/third_party_timeout_test.go
+++ b/lib/cher/third_party_timeout_test.go
@@ -15,7 +15,7 @@ type testErr struct {
 func (e testErr) Error() string { return e.error }
 func (e testErr) Timeout() bool { return e.timeout }
 
-func TestThirdPartyTripperware_RoundTrip(t1 *testing.T) {
+func TestCoerceThirdPartyTimeout(t1 *testing.T) {
 	tests := []struct {
 		name   string
 		err    error

--- a/lib/clog/clog.go
+++ b/lib/clog/clog.go
@@ -260,6 +260,12 @@ func DetermineLevel(err error, timeoutsAsErrors bool) logrus.Level {
 		return logrus.InfoLevel
 	}
 
+	// pgx pool request context cancelled while connecting
+	if strings.Contains(err.Error(), "operation was canceled") &&
+		strings.Contains(err.Error(), "failed to connect to") {
+		return logrus.InfoLevel
+	}
+
 	// non-cher errors are "unhandled" so warrant an error
 	return logrus.ErrorLevel
 }


### PR DESCRIPTION
This PR will reduce error log noise for normal occurrences of requests which are cancelled by our clients when a customer changes screen while the screen is loading.