### PR TITLE
cher: third party timeout

### DIFF
--- a/lib/cher/error.go
+++ b/lib/cher/error.go
@@ -25,6 +25,7 @@ const (
 	EOF               = "eof"
 	UnexpectedEOF     = "unexpected_eof"
 	RequestTimeout    = "request_timeout"
+	ThirdPartyTimeout = "third_party_timeout"
 
 	CoercionError = "unable_to_coerce_error"
 )

--- a/lib/cher/third_party_timeout.go
+++ b/lib/cher/third_party_timeout.go
@@ -1,0 +1,21 @@
+package cher
+
+import (
+	"errors"
+)
+
+type timeoutError interface {
+	Error() string
+	Timeout() bool
+}
+
+func CoerceThirdPartyTimeout(err error) error {
+	var netErr timeoutError
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return New(ThirdPartyTimeout, M{
+			"error": netErr.Error(),
+		})
+	}
+
+	return err
+}

--- a/lib/cher/third_party_timeout_test.go
+++ b/lib/cher/third_party_timeout_test.go
@@ -1,0 +1,59 @@
+package cher
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testErr struct {
+	error   string
+	timeout bool
+}
+
+func (e testErr) Error() string { return e.error }
+func (e testErr) Timeout() bool { return e.timeout }
+
+func TestThirdPartyTripperware_RoundTrip(t1 *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		expect func(t *testing.T, err error)
+	}{
+		{
+			name: "wrapped timeout error",
+			err: fmt.Errorf("wrap: %w", testErr{
+				error:   "foobar",
+				timeout: true,
+			}),
+			expect: func(t *testing.T, err error) {
+				var cErr E
+				require.ErrorAs(t, err, &cErr)
+				require.Equal(t, "third_party_timeout", cErr.Code)
+				require.Equal(t, "example.cuvva.com", cErr.Meta["host"])
+				require.Equal(t, "foobar", cErr.Meta["reason"])
+			},
+		},
+		{
+			name: "other error",
+			err:  fmt.Errorf("any error"),
+			expect: func(t *testing.T, err error) {
+				require.EqualError(t, err, "any error")
+			},
+		},
+		{
+			name: "no error",
+			err:  nil,
+			expect: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+	for _, tc := range tests {
+		t1.Run(tc.name, func(t *testing.T) {
+			err := CoerceThirdPartyTimeout(tc.err)
+			tc.expect(t, err)
+		})
+	}
+}

--- a/lib/cher/third_party_timeout_test.go
+++ b/lib/cher/third_party_timeout_test.go
@@ -31,8 +31,7 @@ func TestThirdPartyTripperware_RoundTrip(t1 *testing.T) {
 				var cErr E
 				require.ErrorAs(t, err, &cErr)
 				require.Equal(t, "third_party_timeout", cErr.Code)
-				require.Equal(t, "example.cuvva.com", cErr.Meta["host"])
-				require.Equal(t, "foobar", cErr.Meta["reason"])
+				require.Equal(t, "foobar", cErr.Meta["error"])
 			},
 		},
 		{

--- a/lib/workerpool/pool.go
+++ b/lib/workerpool/pool.go
@@ -66,12 +66,13 @@ func (w *Worker) Do(fns ...WorkerFunc) {
 			return
 		default:
 			atomic.AddInt64(&w.activeOperations, 1)
+			f := fn
 			go func() {
 				select {
 				case <-w.ctx.Done():
 					return
 				default:
-					w.pendingTasks <- fn
+					w.pendingTasks <- f
 				}
 			}()
 		}


### PR DESCRIPTION
This will allow us to reduce error log noise by explicitly handling third party timeouts in time endpoints, allow the cher error code to propagate all the way up to the service which is controlling the request.

That service and all services in between can log it as a warning.

We can then add a generic alarm on each service which watches for the error code `third_party_timeout` and will fire only if there are more than X warnings in Y time.