### PR TITLE
cdep: fix error typo

### DIFF
--- a/tools/cdep/app/update.go
+++ b/tools/cdep/app/update.go
@@ -69,7 +69,7 @@ func (a App) Update(ctx context.Context, req *parsers.Params, overruleChecks []s
 
 	defaultRef := fmt.Sprintf("refs/heads/%s", cdep.DefaultBranch)
 	if ref.Name().String() != defaultRef {
-		return cher.New("config_not_on_mater", nil)
+		return cher.New("config_not_on_master", nil)
 	}
 
 	log.Info("pulling config repo from remote")

--- a/tools/cdep/cdep.go
+++ b/tools/cdep/cdep.go
@@ -6,7 +6,7 @@ const Version = "0.6"
 const DefaultBranch = "master"
 
 var ErrorCodeMapping = map[string]string{
-	"config_not_on_mater":       "Your config repo is not on master, please swap your HEAD back to master.",
+	"config_not_on_master":      "Your config repo is not on master, please swap your HEAD back to master.",
 	"frozen_without_commit":     "We found a resource where the config is locked, but no commit is specified.",
 	"frozen":                    "The resource you're trying to update is currently frozen.",
 	"nothing_changed":           "Running this tool has resulted in no change.",


### PR DESCRIPTION
# Description
`config_not_on_mater` should be `config_not_on_master`.

OG error
```
Error: config_not_on_mater
```