### PR TITLE
cdep: support yaml files for services

### DIFF
--- a/tools/cdep/app/update_default.go
+++ b/tools/cdep/app/update_default.go
@@ -114,7 +114,7 @@ func (a App) UpdateDefault(ctx context.Context, req *parsers.Params, overruleChe
 				fullPath := path.Join(p, file.Name())
 				var changed bool
 
-				if strings.Contains(fullPath, "_base.json") {
+				if strings.HasSuffix(fullPath, "_base.json") || strings.HasSuffix(fullPath, ".yaml") {
 					changed, err = a.AddToConfig(fullPath, req.Branch, latestHash)
 					if err != nil {
 						return err

--- a/tools/cdep/paths/services.go
+++ b/tools/cdep/paths/services.go
@@ -7,3 +7,7 @@ import (
 func GetPathForService(repo, system, env, service string) string {
 	return path.Join(repo, system, env, "service", service+".json")
 }
+
+func GetYamlPathForService(repo, system, env, service string) string {
+	return path.Join(repo, system, env, "service", service+".yaml")
+}

--- a/tools/cdep/systems.go
+++ b/tools/cdep/systems.go
@@ -14,6 +14,7 @@ var Systems = map[string]map[string]struct{}{
 		"coconut":   {},
 		"dwight":    {},
 		"eggplant":  {},
+		"pretzel":   {},
 		"ephemeral": {},
 		"test":      {},
 		"all":       {},


### PR DESCRIPTION
during `update service` if the json file doesn't exist, try the yaml file

during `update-default service` if it encounters a yaml file, it sets the branch and commit in the file rather than removing it. (no such thing as _base.yaml)

this allows up to cdep services in the argocd managed pretzel environment