### PR TITLE
cdep: add terraform workspace types

### DIFF
--- a/tools/cdep/app/publish_slack.go
+++ b/tools/cdep/app/publish_slack.go
@@ -6,14 +6,13 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/cuvva/cuvva-public-go/tools/cdep/parsers"
-
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/cuvva/cuvva-public-go/tools/cdep/parsers"
 )
 
 func (a App) PublishToSlack(ctx context.Context, req *parsers.Params, commitMessage string, updatedFiles []string, repoPath string) error {
-	user, err := exec.CommandContext(ctx, "git", "config", "user.name").Output()
+	user, err := exec.CommandContext(ctx, "git", "config", "user.name").CombinedOutput()
 	if err != nil {
 		fmt.Println(string(user))
 		return err

--- a/tools/cdep/app/update.go
+++ b/tools/cdep/app/update.go
@@ -43,7 +43,7 @@ func (a App) Update(ctx context.Context, req *parsers.Params, overruleChecks []s
 
 	log.Info("fetching config repo")
 
-	if out, err := exec.CommandContext(ctx, "git", "-C", repoPath, "fetch", "--all").Output(); err != nil {
+	if out, err := exec.CommandContext(ctx, "git", "-C", repoPath, "fetch", "--all").CombinedOutput(); err != nil {
 		fmt.Println(string(out))
 		return err
 	}
@@ -69,14 +69,18 @@ func (a App) Update(ctx context.Context, req *parsers.Params, overruleChecks []s
 
 	defaultRef := fmt.Sprintf("refs/heads/%s", cdep.DefaultBranch)
 	if ref.Name().String() != defaultRef {
-		return cher.New("config_not_on_master", nil)
+		if !slicecontains.String(overruleChecks, "config_not_on_master") {
+			return cher.New("config_not_on_master", nil)
+		}
+
+		log.Warn("config_not_on_master overruled")
 	}
 
 	log.Info("pulling config repo from remote")
 
-	if out, err := exec.CommandContext(ctx, "git", "-C", repoPath, "pull", "origin", cdep.DefaultBranch).Output(); err != nil {
+	if out, err := exec.CommandContext(ctx, "git", "-C", repoPath, "pull").CombinedOutput(); err != nil {
 		fmt.Println(string(out))
-		return err
+		return fmt.Errorf("git pull: %w", err)
 	}
 
 	wt, err := configRepo.Worktree()
@@ -206,7 +210,7 @@ func (a App) Update(ctx context.Context, req *parsers.Params, overruleChecks []s
 
 	log.Info("pushing commit to config repo")
 
-	if out, err := exec.CommandContext(ctx, "git", "-C", repoPath, "push", "origin", cdep.DefaultBranch).Output(); err != nil {
+	if out, err := exec.CommandContext(ctx, "git", "-C", repoPath, "push", "origin", "HEAD").CombinedOutput(); err != nil {
 		fmt.Println(string(out))
 		return fmt.Errorf("config git push: %w", err)
 	}

--- a/tools/cdep/app/update.go
+++ b/tools/cdep/app/update.go
@@ -152,6 +152,24 @@ func (a App) Update(ctx context.Context, req *parsers.Params, overruleChecks []s
 					updatedFiles = append(updatedFiles, shorthandPath)
 				}
 			}
+		case "terra": // terraform
+			for _, workspace := range req.Items {
+				p := paths.GetPathForTerra(repoPath, req.System, env, workspace)
+
+				if _, err := os.Stat(p); err != nil {
+					log.Warn(err)
+				}
+
+				changed, err := a.AddToConfig(p, req.Branch, latestHash)
+				if err != nil {
+					return err
+				}
+
+				if changed {
+					shorthandPath := path.Join(req.System, env, "terra", workspace+".json")
+					updatedFiles = append(updatedFiles, shorthandPath)
+				}
+			}
 		default:
 			return cher.New("unexpected_type", cher.M{"type": req.Type})
 		}

--- a/tools/cdep/app/update_default.go
+++ b/tools/cdep/app/update_default.go
@@ -33,7 +33,7 @@ func (a App) UpdateDefault(ctx context.Context, req *parsers.Params, overruleChe
 
 	log.Info("fetching config repo")
 
-	if out, err := exec.CommandContext(ctx, "git", "-C", repoPath, "fetch", "--all").Output(); err != nil {
+	if out, err := exec.CommandContext(ctx, "git", "-C", repoPath, "fetch", "--all").CombinedOutput(); err != nil {
 		fmt.Println(string(out))
 		return err
 	}
@@ -64,7 +64,7 @@ func (a App) UpdateDefault(ctx context.Context, req *parsers.Params, overruleChe
 
 	log.Info("pulling config repo from remote")
 
-	if out, err := exec.CommandContext(ctx, "git", "-C", repoPath, "pull", "origin", cdep.DefaultBranch).Output(); err != nil {
+	if out, err := exec.CommandContext(ctx, "git", "-C", repoPath, "pull", "origin", cdep.DefaultBranch).CombinedOutput(); err != nil {
 		fmt.Println(string(out))
 		return err
 	}
@@ -170,7 +170,7 @@ func (a App) UpdateDefault(ctx context.Context, req *parsers.Params, overruleChe
 
 	log.Info("pushing commit to config repo")
 
-	if out, err := exec.CommandContext(ctx, "git", "-C", repoPath, "push", "origin", cdep.DefaultBranch).Output(); err != nil {
+	if out, err := exec.CommandContext(ctx, "git", "-C", repoPath, "push", "origin", cdep.DefaultBranch).CombinedOutput(); err != nil {
 		fmt.Println(string(out))
 		return err
 	}

--- a/tools/cdep/parsers/parse.go
+++ b/tools/cdep/parsers/parse.go
@@ -11,7 +11,7 @@ import (
 // exceptions of services that start with "service-"
 var exceptions = map[string]struct{}{
 	"web-underwriter": {},
-	"web-mid": {},
+	"web-mid":         {},
 }
 
 func Parse(args []string, branch string, prodSys bool, message string) (*Params, error) {

--- a/tools/cdep/paths/terra.go
+++ b/tools/cdep/paths/terra.go
@@ -1,0 +1,9 @@
+package paths
+
+import (
+	"path"
+)
+
+func GetPathForTerra(repo, system, env, workspace string) string {
+	return path.Join(repo, system, env, "terra", workspace+".json")
+}

--- a/tools/cdep/types.go
+++ b/tools/cdep/types.go
@@ -7,14 +7,11 @@ import (
 )
 
 var Types = map[string]struct{}{
-	"lambda":     {},
-	"lambdas":    {},
-	"service":    {},
-	"services":   {},
-	"terra":      {},
-	"terras":     {},
-	"terraform":  {},
-	"terraforms": {},
+	"lambda":   {},
+	"lambdas":  {},
+	"service":  {},
+	"services": {},
+	"terra":    {},
 }
 
 func ParseTypeArg(in string) (string, error) {
@@ -30,7 +27,7 @@ func ParseTypeArg(in string) (string, error) {
 		return "service", nil
 	case "lambda", "lambdas":
 		return "lambda", nil
-	case "terra", "terras", "terraform", "terraforms":
+	case "terra":
 		return "terra", nil
 	default:
 		return "", cher.New("impossible", nil)

--- a/tools/cdep/types.go
+++ b/tools/cdep/types.go
@@ -7,10 +7,14 @@ import (
 )
 
 var Types = map[string]struct{}{
-	"lambda":   {},
-	"lambdas":  {},
-	"service":  {},
-	"services": {},
+	"lambda":     {},
+	"lambdas":    {},
+	"service":    {},
+	"services":   {},
+	"terra":      {},
+	"terras":     {},
+	"terraform":  {},
+	"terraforms": {},
 }
 
 func ParseTypeArg(in string) (string, error) {
@@ -26,6 +30,8 @@ func ParseTypeArg(in string) (string, error) {
 		return "service", nil
 	case "lambda", "lambdas":
 		return "lambda", nil
+	case "terra", "terras", "terraform", "terraforms":
+		return "terra", nil
 	default:
 		return "", cher.New("impossible", nil)
 	}


### PR DESCRIPTION
this adds a new type of deployable to cdep `terra`

Usage:
```
cdep update terra pretzel aws-env
cdep update terra all aws-env
cdep update terra pretzel aws-env -b my-branch
```

It also adds a new overrule check to allow me to cdep my config branch that I am using to develop the new github action to auto deploy.

```
cdep update --overrule-checks config_not_on_master terra pretzel aws-env
```

- this also fixes an issue where git shell commands executed wouldn't show their error output because only standard output was being shown.

The new config files exist in this PR https://github.com/cuvva/config/pull/471/files#diff-7190132d243af45f4e7425967f39f3f9d19b79dba215bca76e6d8ecf743f206a