### PR TITLE
cdep commit option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cuvva/cuvva-public-go
 
-go 1.18
+go 1.21
 
 require (
 	github.com/Masterminds/squirrel v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -282,6 +282,7 @@ github.com/hashicorp/go-tfe v0.24.0/go.mod h1:gyXLXbpBVxA2F/6opah8XBsOkZJxHYQmgh
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
+github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=

--- a/tools/cdep/app/update_default.go
+++ b/tools/cdep/app/update_default.go
@@ -21,9 +21,13 @@ import (
 func (a App) UpdateDefault(ctx context.Context, req *parsers.Params, overruleChecks []string) error {
 	log.Info("getting latest commit hash")
 
-	latestHash, err := git.GetLatestCommitHash(ctx, req.Branch)
-	if err != nil {
-		return err
+	if req.Commit == "" {
+		latestHash, err := git.GetLatestCommitHash(ctx, req.Branch)
+		if err != nil {
+			return err
+		}
+
+		req.Commit = latestHash
 	}
 
 	repoPath, err := paths.GetConfigRepo()
@@ -115,7 +119,7 @@ func (a App) UpdateDefault(ctx context.Context, req *parsers.Params, overruleChe
 				var changed bool
 
 				if strings.HasSuffix(fullPath, "_base.json") || strings.HasSuffix(fullPath, ".yaml") {
-					changed, err = a.AddToConfig(fullPath, req.Branch, latestHash)
+					changed, err = a.AddToConfig(fullPath, req.Branch, req.Commit)
 					if err != nil {
 						return err
 					}

--- a/tools/cdep/commands/update.go
+++ b/tools/cdep/commands/update.go
@@ -20,6 +20,7 @@ import (
 
 func init() {
 	UpdateCmd.Flags().StringP("branch", "b", cdep.DefaultBranch, "Branch to deploy")
+	UpdateCmd.Flags().StringP("commit", "c", "", "Commit to deploy instead of the latest")
 	UpdateCmd.Flags().BoolP("prod", "", false, "Work on prod")
 	UpdateCmd.Flags().BoolP("dry-run", "", false, "Dry run only?")
 	UpdateCmd.Flags().StringSliceP("overrule-checks", "", []string{}, "Overrule checks the tool does")
@@ -73,10 +74,19 @@ var UpdateCmd = &cobra.Command{
 			return err
 		}
 
-		params, err := parsers.Parse(args, branch, useProd, message)
+		commit, err := cmd.Flags().GetString("commit")
 		if err != nil {
 			return err
 		}
+
+		params, err := parsers.Parse(args, useProd)
+		if err != nil {
+			return err
+		}
+
+		params.Branch = branch
+		params.Message = message
+		params.Commit = commit
 
 		awsSession, err := session.NewSessionWithOptions(session.Options{
 			Profile: "root",

--- a/tools/cdep/commands/update.go
+++ b/tools/cdep/commands/update.go
@@ -45,9 +45,12 @@ var UpdateCmd = &cobra.Command{
 	Long:  "Please read the README.md file",
 	Example: strings.Join([]string{
 		"update service avocado sms email -b extra-logging",
-		"update lambda basil ltm-proxy",
+		"update service avocado sms email -b extra-logging -c f1ec178befe6ed26ce9cec0aa419c763c203bc92",
+		"update service all sms email -c 1ed6fd7450031a5240584f8bbe8ec527f9020b5b",
 		"update service prod email --prod",
+		"update lambda basil ltm-proxy",
 		"update cloudfront prod website --prod",
+		"update terra avocado aws-env",
 	}, "\n"),
 	Aliases: []string{"u"},
 	Args:    updateArgs,

--- a/tools/cdep/commands/update_default.go
+++ b/tools/cdep/commands/update_default.go
@@ -63,10 +63,19 @@ var UpdateDefaultCmd = &cobra.Command{
 			return err
 		}
 
-		params, err := parsers.Parse(args, cdep.DefaultBranch, useProd, message)
+		commit, err := cmd.Flags().GetString("commit")
 		if err != nil {
 			return err
 		}
+
+		params, err := parsers.Parse(args, useProd)
+		if err != nil {
+			return err
+		}
+
+		params.Branch = cdep.DefaultBranch
+		params.Message = message
+		params.Commit = commit
 
 		awsSession, err := session.NewSessionWithOptions(session.Options{
 			Profile: "root",

--- a/tools/cdep/commands/update_default.go
+++ b/tools/cdep/commands/update_default.go
@@ -42,6 +42,7 @@ var UpdateDefaultCmd = &cobra.Command{
 	Long:  "Please read the README.md file",
 	Example: strings.Join([]string{
 		"update-default services avocado",
+		"update-default services avocado -c f1ec178befe6ed26ce9cec0aa419c763c203bc92",
 		"update-default lambda all",
 	}, "\n"),
 	Args: updateDefaultArgs,

--- a/tools/cdep/parsers/parse.go
+++ b/tools/cdep/parsers/parse.go
@@ -14,7 +14,7 @@ var exceptions = map[string]struct{}{
 	"web-mid":         {},
 }
 
-func Parse(args []string, branch string, prodSys bool, message string) (*Params, error) {
+func Parse(args []string, prodSys bool) (*Params, error) {
 	if len(args) < 2 {
 		return nil, errors.New("missing arguments")
 	}
@@ -65,8 +65,6 @@ func Parse(args []string, branch string, prodSys bool, message string) (*Params,
 		Type:        t,
 		System:      system,
 		Environment: args[1],
-		Branch:      branch,
 		Items:       itemSet,
-		Message:     message,
 	}, nil
 }

--- a/tools/cdep/parsers/type.go
+++ b/tools/cdep/parsers/type.go
@@ -9,6 +9,7 @@ type Params struct {
 	Type        string
 	Environment string
 	Branch      string
+	Commit      string
 	System      string
 	Items       []string
 	Message     string
@@ -29,6 +30,10 @@ func (p Params) String(command string) (out string) {
 
 	if p.Branch != "master" {
 		out = fmt.Sprintf("%s -b %s", out, p.Branch)
+	}
+
+	if p.Commit != "" {
+		out = fmt.Sprintf("%s -c %s", out, p.Commit)
 	}
 
 	if p.System == "prod" {


### PR DESCRIPTION
people are having problems with the go git client authorisation, this allows them to specify the commit instead of it looking up the latest.

this means they can still use the tool to avoid mistakes.

```
cdep update service avocado motor-coverage -b branch -c branch-commit-hash
cdep update service all motor-coverage -c master-commit-hash
cdpe update-default service all -c master-commit-hash
```