### PR TITLE
cprc & jsonclient: support request modifiers

### DIFF
--- a/lib/crpc/client.go
+++ b/lib/crpc/client.go
@@ -42,8 +42,8 @@ func (c *Client) WithUASuffix(suffix string) *Client {
 }
 
 // Do executes an RPC request against the configured server.
-func (c *Client) Do(ctx context.Context, method, version string, src, dst interface{}) error {
-	err := c.Client.Do(ctx, "POST", path.Join(version, method), nil, src, dst)
+func (c *Client) Do(ctx context.Context, method, version string, src, dst interface{}, requestModifiers ...func(r *http.Request)) error {
+	err := c.Client.Do(ctx, "POST", path.Join(version, method), nil, src, dst, requestModifiers...)
 
 	if err == nil {
 		return nil

--- a/lib/jsonclient/jsonclient.go
+++ b/lib/jsonclient/jsonclient.go
@@ -64,12 +64,12 @@ func NewClient(baseURL string, c *http.Client) *Client {
 }
 
 // Do executes an HTTP request against the configured server.
-func (c *Client) Do(ctx context.Context, method, path string, params url.Values, src, dst interface{}) error {
-	return c.DoWithHeaders(ctx, method, path, nil, params, src, dst)
+func (c *Client) Do(ctx context.Context, method, path string, params url.Values, src, dst interface{}, requestModifiers ...func(r *http.Request)) error {
+	return c.DoWithHeaders(ctx, method, path, nil, params, src, dst, requestModifiers...)
 }
 
 // DoWithHeaders executes an HTTP request against the configured server with custom headers.
-func (c *Client) DoWithHeaders(ctx context.Context, method, path string, headers http.Header, params url.Values, src, dst interface{}) error {
+func (c *Client) DoWithHeaders(ctx context.Context, method, path string, headers http.Header, params url.Values, src, dst interface{}, requestModifiers ...func(r *http.Request)) error {
 	if c.Client == nil {
 		c.Client = http.DefaultClient
 	}
@@ -102,6 +102,10 @@ func (c *Client) DoWithHeaders(ctx context.Context, method, path string, headers
 
 	for key, value := range headers {
 		req.Header[key] = value
+	}
+
+	for _, modifier := range requestModifiers {
+		modifier(req)
 	}
 
 	err := c.setRequestBody(req, src)

--- a/lib/jsonclient/jsonclient_test.go
+++ b/lib/jsonclient/jsonclient_test.go
@@ -110,6 +110,30 @@ func TestRequestBody(t *testing.T) {
 	assert.True(t, gock.IsDone())
 }
 
+func TestRequestModifier(t *testing.T) {
+	defer gock.Off()
+
+	testJSON := map[string]bool{"testing": true}
+
+	modifier := func(req *http.Request) {
+		req.Header.Add("X-Test-Header", "test")
+	}
+
+	gock.New("http://coo.va/").
+		Post("/test").
+		MatchType("application/json; charset=utf-8").
+		JSON(testJSON).
+		MatchHeader("X-Test-Header", "test").
+		Reply(http.StatusNoContent)
+
+	client := NewClient("http://coo.va/", nil)
+	gock.InterceptClient(client.Client)
+
+	err := client.Do(context.Background(), "POST", "test", nil, testJSON, nil, modifier)
+	assert.Nil(t, err)
+	assert.True(t, gock.IsDone())
+}
+
 func TestResponseBody(t *testing.T) {
 	defer gock.Off()
 


### PR DESCRIPTION
- `Do` method now takes optional request modifier functions to be applied to the request object
- This allows us to customise headers, e.g. allowing us to pass through the original client metadata when making service-service requests