### PR TITLE
clog: show underlying cher error_code

### DIFF
--- a/lib/clog/clog.go
+++ b/lib/clog/clog.go
@@ -199,6 +199,7 @@ func SetError(ctx context.Context, err error) error {
 
 	cherErr := cher.E{}
 	if errors.As(err, &cherErr) {
+		ctxLogger.SetField("error_code", cherErr.Code)
 		if len(cherErr.Reasons) > 0 {
 			ctxLogger.SetField("error_reasons", cherErr.Reasons)
 		}


### PR DESCRIPTION
if your error gets wrapped you see:
`error = "my wrapper: my_cher_code"`

now you also see the underlying cher code:
`error_code = "my_cher_code"`

this helps to do analytics and log filtering on underlying errors.