### PR TITLE
Improve log env names

### DIFF
--- a/lib/clog/clog.go
+++ b/lib/clog/clog.go
@@ -46,7 +46,7 @@ type Config struct {
 	// Format configures the output format. Possible options:
 	//   - text - logrus default text output, good for local development
 	//   - json - fields and message encoded as json, good for storage in e.g. cloudwatch
-	Format string `json:"format" env:"FORMAT" envDefault:"json"`
+	Format string `json:"format" env:"LOG_FORMAT" envDefault:"json"`
 
 	// Debug enables debug level logging, otherwise INFO level
 	Debug bool `json:"debug" env:"DEBUG" envDefault:"false"`

--- a/lib/clog/clog.go
+++ b/lib/clog/clog.go
@@ -46,10 +46,10 @@ type Config struct {
 	// Format configures the output format. Possible options:
 	//   - text - logrus default text output, good for local development
 	//   - json - fields and message encoded as json, good for storage in e.g. cloudwatch
-	Format string `json:"format"`
+	Format string `json:"format" env:"FORMAT" envDefault:"json"`
 
 	// Debug enables debug level logging, otherwise INFO level
-	Debug bool `json:"debug"`
+	Debug bool `json:"debug" env:"DEBUG" envDefault:"false"`
 }
 
 // Configure applies Cuvva standard Logging structure options to a logrus Entry.

--- a/lib/config/aws.go
+++ b/lib/config/aws.go
@@ -15,6 +15,7 @@ import (
 // AWS configures credentials for access to Amazon Web Services.
 // It is intended to be used in composition rather than a key.
 type AWS struct {
+	AccountID       string `json:"account_id" env:"AWS_ACCOUNT_ID"`
 	AccessKeyID     string `json:"access_key_id" env:"AWS_ACCESS_KEY_ID"`
 	AccessKeySecret string `json:"access_key_secret" env:"AWS_SECRET_ACCESS_KEY"`
 

--- a/lib/config/aws.go
+++ b/lib/config/aws.go
@@ -15,7 +15,6 @@ import (
 // AWS configures credentials for access to Amazon Web Services.
 // It is intended to be used in composition rather than a key.
 type AWS struct {
-	AccountID       string `json:"account_id" env:"AWS_ACCOUNT_ID"`
 	AccessKeyID     string `json:"access_key_id" env:"AWS_ACCESS_KEY_ID"`
 	AccessKeySecret string `json:"access_key_secret" env:"AWS_SECRET_ACCESS_KEY"`
 

--- a/lib/config/aws.go
+++ b/lib/config/aws.go
@@ -15,10 +15,10 @@ import (
 // AWS configures credentials for access to Amazon Web Services.
 // It is intended to be used in composition rather than a key.
 type AWS struct {
-	AccessKeyID     string `json:"access_key_id"`
-	AccessKeySecret string `json:"access_key_secret"`
+	AccessKeyID     string `json:"access_key_id" env:"AWS_ACCESS_KEY_ID"`
+	AccessKeySecret string `json:"access_key_secret" env:"AWS_SECRET_ACCESS_KEY"`
 
-	Region string `json:"region,omitempty"`
+	Region string `json:"region,omitempty" env:"AWS_REGION"`
 }
 
 // Credentials returns a configured set of AWS credentials.


### PR DESCRIPTION
Change env names for logging to make them simpler. Previously I was adding a prefix in the application `LOG_`

But now I just keep them as fully qualified here.