### PR TITLE
cdep also update image tags in json

### DIFF
--- a/tools/cdep/app/add_config.go
+++ b/tools/cdep/app/add_config.go
@@ -109,20 +109,6 @@ func attemptInsert(blob []byte, key string, value interface{}) []byte {
 	return blob
 }
 
-// attemptInsertYaml attempts to insert a key into the struct if it doesn't exist
-func attemptInsertYaml(blob []byte, key string, value interface{}) []byte {
-	strBlob := string(blob)
-
-	// if it does not exist, add it
-	if pos := strings.Index(strBlob, key); pos == -1 {
-		strBlob = fmt.Sprintf("%s: %s\n", key, value) + strBlob
-	}
-
-	blob = []byte(strBlob)
-
-	return blob
-}
-
 // attemptUpdate attempts to change a value of a key if it already exists
 func attemptUpdate(blob []byte, reg *regexp.Regexp, key, value string) []byte {
 	if reg.Match(blob) {

--- a/tools/cdep/app/add_config.go
+++ b/tools/cdep/app/add_config.go
@@ -15,6 +15,7 @@ var commitFreeze = regexp.MustCompile(`(?m)"cdep_freeze"\s*:\s*true`)
 
 var commitRegAdd = regexp.MustCompile(`"commit"\s*:\s*"[a-f\d]{40}"`)
 var branchRegAdd = regexp.MustCompile(`"branch"\s*:\s*"([^"]+)"`)
+var imageTagRegAdd = regexp.MustCompile(`"tag"\s*:\s*"([^"]+)"`)
 
 var commitRegAddYaml = regexp.MustCompile(`commit\s*:\s*"?[a-f\d]{40}"?`)
 var imageTagRegAddYaml = regexp.MustCompile(`tag\s*:\s*"?[a-z\d-]+"?`)
@@ -62,8 +63,14 @@ func (a App) doJsonUpdates(path string, branchName string, commitHash string, bl
 		return blob
 	}
 
+	imagePrefix := "master"
+	if branchName != "master" {
+		imagePrefix = "branch"
+	}
+
 	blob = attemptUpdate(blob, commitRegAdd, "commit", commitHash)
 	blob = attemptUpdate(blob, branchRegAdd, "branch", branchName)
+	blob = attemptUpdate(blob, imageTagRegAdd, "tag", fmt.Sprintf("%s-%s", imagePrefix, commitHash))
 
 	blob = attemptInsert(blob, "commit", commitHash)
 	blob = attemptInsert(blob, "branch", branchName)
@@ -84,9 +91,6 @@ func (a App) doYamlUpdates(path string, branchName string, commitHash string, bl
 	blob = attemptUpdateYaml(blob, commitRegAddYaml, "commit", commitHash)
 	blob = attemptUpdateYaml(blob, branchRegAddYaml, "branch", branchName)
 	blob = attemptUpdateYaml(blob, imageTagRegAddYaml, "tag", fmt.Sprintf("%s-%s", imagePrefix, commitHash))
-
-	blob = attemptInsertYaml(blob, "commit", commitHash)
-	blob = attemptInsertYaml(blob, "branch", branchName)
 	return blob
 }
 


### PR DESCRIPTION
this makes cdep also update image tags for sidecars that use the same source repository as the main container.

this means that the sidecars for consuming crpc-queues will track the same released build as the main container.

we may need to do something more complicated in future but this works for now.