### PR TITLE
cdep: provide datadog dashboard URLs

### DIFF
--- a/tools/cdep/app/dashboards.go
+++ b/tools/cdep/app/dashboards.go
@@ -1,0 +1,100 @@
+package app
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/cuvva/cuvva-public-go/tools/cdep/parsers"
+)
+
+type Dashboard struct {
+	Name string
+	URL  string
+}
+
+func chooseDashboards(req *parsers.Params, envNames []string) []Dashboard {
+	var dashboards []Dashboard
+	switch req.Type {
+	case "service":
+		dashboards = append(dashboards, Dashboard{
+			Name: "Deployment Status",
+			URL:  deploymentStatusDashboard(envNames, req.Items),
+		})
+	}
+
+	switch req.System {
+	case "prod":
+		dashboards = append(dashboards, Dashboard{
+			Name: "Prod Errors (inc lambda)",
+			URL:  "https://app.datadoghq.eu/logs?saved-view-id=48532",
+		})
+	default:
+		dashboards = append(dashboards, Dashboard{
+			Name: "Nonprod Errors",
+			URL:  "https://app.datadoghq.eu/logs?saved-view-id=42541",
+		})
+	}
+
+	return dashboards
+}
+
+func printDashboards(dashboards []Dashboard) {
+	if len(dashboards) == 0 {
+		return
+	}
+
+	for _, dashboard := range dashboards {
+		fmt.Println("")
+		fmt.Println(dashboard.Name)
+		fmt.Println(dashboard.URL)
+	}
+
+	fmt.Println("")
+}
+
+func deploymentStatusDashboard(envs []string, services []string) string {
+	for i, svc := range services {
+		services[i] = strings.TrimPrefix(svc, "service-")
+	}
+
+	endpoint := "https://app.datadoghq.eu/logs"
+	query := url.Values{
+		"query": []string{
+			fmt.Sprintf(
+				"source:service env:(%s) service:(%s)",
+				strings.Join(envs, " OR "),
+				strings.Join(services, " OR "),
+			),
+		},
+		"agg_m":            []string{"count"},
+		"agg_m_source":     []string{"base"},
+		"agg_q":            []string{"@_commit_hash,status"},
+		"agg_q_source":     []string{"base,base"},
+		"agg_t":            []string{"count"},
+		"analyticsOptions": []string{`["bars","dog_classic",null,null,"value"]`},
+		"cols":             []string{"service,@level,@rpc_method,@message,@error,@http_duration"},
+		"fromUser":         []string{"true"},
+		"messageDisplay":   []string{"inline"},
+		"refresh_mode":     []string{"sliding"},
+		"saved-view-id":    []string{"152718"},
+		"sort_m":           []string{"count,count"},
+		"sort_m_source":    []string{"base,base"},
+		"sort_t":           []string{"count,count"},
+		"storage":          []string{"hot"},
+		"stream_sort":      []string{"desc"},
+		"top_n":            []string{"5,5"},
+		"top_o":            []string{"top,top"},
+		"viz":              []string{"timeseries"},
+		"x_missing":        []string{"true,true"},
+		"from_ts":          []string{"1739785059959"},
+		"to_ts":            []string{"1739785959959"},
+		"live":             []string{"true"},
+	}
+
+	return fmt.Sprintf(
+		"%s?%s",
+		endpoint,
+		query.Encode(),
+	)
+}

--- a/tools/cdep/app/update.go
+++ b/tools/cdep/app/update.go
@@ -109,7 +109,10 @@ func (a App) Update(ctx context.Context, req *parsers.Params, overruleChecks []s
 		return fmt.Errorf("load envs: %w", err)
 	}
 
+	var envNames []string
 	for env := range envs {
+		envNames = append(envNames, env)
+
 		switch req.Type {
 		case "service":
 			for _, service := range req.Items {
@@ -191,6 +194,10 @@ func (a App) Update(ctx context.Context, req *parsers.Params, overruleChecks []s
 	if err := a.PublishToSlack(ctx, req, commitMessage, updatedFiles, repoPath); err != nil {
 		return fmt.Errorf("publish to slack: %w", err)
 	}
+
+	dashboards := chooseDashboards(req, envNames)
+
+	printDashboards(dashboards)
 
 	if a.DryRun {
 		log.Info("Dry run only, stopping now")


### PR DESCRIPTION
Example 
```
INFO[0000] getting latest commit hash
INFO[0004] fetching config repo
INFO[0005] opening config repo
INFO[0005] pulling config repo from remote
INFO[0007] adding hash and branch to json files
INFO[0007] loading ALL environments
WARN[0012] Custom branch is going to be overriden, old: dlr-quote-enable-bgr, new: master, path: /Users/jules/code/config/nonprod/avocado/service/service-quote.yaml
Override branch? (y/n) n

Deployment Status
https://app.datadoghq.eu/logs?agg_m=count&agg_m_source=base&agg_q=%40_commit_hash%2Cstatus&agg_q_source=base%2Cbase&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&cols=service%2C%40level%2C%40rpc_method%2C%40message%2C%40error%2C%40http_duration&fromUser=true&from_ts=1739785059959&live=true&messageDisplay=inline&query=source%3Aservice+env%3A%28basil+OR+coconut+OR+ephemeral+OR+pretzel+OR+test+OR+avocado%29+service%3A%28quote+OR+motor-coverage%29&refresh_mode=sliding&saved-view-id=152718&sort_m=count%2Ccount&sort_m_source=base%2Cbase&sort_t=count%2Ccount&storage=hot&stream_sort=desc&to_ts=1739785959959&top_n=5%2C5&top_o=top%2Ctop&viz=timeseries&x_missing=true%2Ctrue

Nonprod Errors
https://app.datadoghq.eu/logs?saved-view-id=42541

INFO[0030] Dry run only, stopping now
INFO[0030] commit message (cdep: update service all quote motor-coverage -c e89a45e1dbb1aefbcaebe9dbab1114c868bb235a)
```