### PR TITLE
config: redis client lazy connects

### DIFF
--- a/lib/config/redis.go
+++ b/lib/config/redis.go
@@ -28,7 +28,7 @@ func (r Redis) Options() (*redis.Options, error) {
 	return opts, nil
 }
 
-// Connect returns a connected redis.Client instance.
+// Connect returns a redis.Client instance that will attempt to connect when first used.
 func (r Redis) Connect() (*redis.Client, error) {
 	opts, err := r.Options()
 	if err != nil {
@@ -36,10 +36,6 @@ func (r Redis) Connect() (*redis.Client, error) {
 	}
 
 	client := redis.NewClient(opts)
-
-	if err := client.Ping().Err(); err != nil {
-		return client, err
-	}
 
 	return client, nil
 }


### PR DESCRIPTION
This changes all go services to lazy connect to redis, this means they can boot when redis isn't available.

There is a tiny performance hit that the first request to hit the service isn't primed with a ready redis connection. But if a service is high traffic and the service needs to keep multiple connections running to redis, then this delay would happen under normal conditions for plenty of requests anyway.

Alternatives could be to create a new method, and migration services we want over to use it. Or we could still call the ping method to try prime one connection, but ignore/log the error.