### PR TITLE
clog: add func WithCherFields

### DIFF
--- a/lib/clog/clog.go
+++ b/lib/clog/clog.go
@@ -212,6 +212,21 @@ func SetError(ctx context.Context, err error) error {
 	return nil
 }
 
+func WithCherFields(entry *logrus.Entry, err error) *logrus.Entry {
+	cherErr := cher.E{}
+	if errors.As(err, &cherErr) {
+		if len(cherErr.Reasons) > 0 {
+			entry = entry.WithField("error_reasons", cherErr.Reasons)
+		}
+
+		if cherErr.Meta != nil {
+			entry = entry.WithField("error_meta", cherErr.Meta)
+		}
+	}
+
+	return entry
+}
+
 // ConfigureTimeoutsAsErrors changes to default behaviour of logging timeouts as info, to log them as errors
 func ConfigureTimeoutsAsErrors(ctx context.Context) {
 	ctxLogger := getContextLogger(ctx)

--- a/lib/clog/clog_test.go
+++ b/lib/clog/clog_test.go
@@ -166,3 +166,41 @@ func TestDetermineLevel(t *testing.T) {
 		})
 	}
 }
+
+func TestWithCherFields(t *testing.T) {
+	t.Run("With cher.E containing reasons and meta", func(t *testing.T) {
+		entry := logrus.NewEntry(logrus.New())
+		err := cher.E{
+			Code:    "test_error",
+			Reasons: []cher.E{{Code: "reason_1"}, {Code: "reason_2"}},
+			Meta:    map[string]interface{}{"key": "value"},
+		}
+
+		result := WithCherFields(entry, err)
+
+		assert.Equal(t, []cher.E{{Code: "reason_1"}, {Code: "reason_2"}}, result.Data["error_reasons"])
+		assert.Equal(t, map[string]interface{}{"key": "value"}, result.Data["error_meta"])
+	})
+
+	t.Run("With cher.E containing no reasons or meta", func(t *testing.T) {
+		entry := logrus.NewEntry(logrus.New())
+		err := cher.E{
+			Code: "test_error",
+		}
+
+		result := WithCherFields(entry, err)
+
+		assert.NotContains(t, result.Data, "error_reasons")
+		assert.NotContains(t, result.Data, "error_meta")
+	})
+
+	t.Run("With non-cher error", func(t *testing.T) {
+		entry := logrus.NewEntry(logrus.New())
+		err := errors.New("non-cher error")
+
+		result := WithCherFields(entry, err)
+
+		assert.NotContains(t, result.Data, "error_reasons")
+		assert.NotContains(t, result.Data, "error_meta")
+	})
+}


### PR DESCRIPTION
This allows you to add the Cher meta and reasons to an error handle that logs and continues.

E.g.

```
clog.WithCherFields(clog.Get(ctx)).
  WithField("segment_id", p.ID), err).
  Error(fmt.Errorf("skipping policy: %w", err))
```