### PR TITLE
cdep: add ability to deploy go only & js only

### DIFF
--- a/cmd/cdep/README.md
+++ b/cmd/cdep/README.md
@@ -13,11 +13,30 @@ A CLI tool to deploy things to a specific environment. Covers both orchestrated 
 
 This tool is designed to speed up quick day-to-day updates, and is not meant to be all encompassing.
 
-`cdep update {type} {env|all} {...services}`
+`cdep update {type} {env|all} {...services|all}`
+
+#### Updating All Services
+
+You can now use `all` as the service name to update all services in an environment:
+
+- `cdep update service avocado all` - Updates all services in avocado environment
+- `cdep update service all all` - Updates all services in all environments
+
+#### Service Filtering for Update Command
+
+The `update` command now supports the same filtering options as `update-default`:
+
+- `--go-only`: Only update Go services (services with `docker_image_name: go_services` or `go-services`)
+- `--js-only`: Only update JS services (services with `docker_image_name` != `go_services`/`go-services`)
+
+Examples:
+- `cdep update service avocado all --go-only -c abc123` - Update only Go services in avocado
+- `cdep update service all all --js-only -c abc123` - Update only JS services in all environments
 
 For example:
 
 - `cdep u service avocado -b fix-it sms ltm email web-underwriter`
+- `cdep u service avocado all -c f1ec178befe6ed26ce9cec0aa419c763c203bc92`
 - `cdep u service all sms`
 - `cdep u lambda avocado -b fix-it marketing-consent stm-policy-sale`
 - `cdep u service prod ltm --prod`
@@ -57,8 +76,10 @@ This command will find all services on the `master` branch and remove that from 
 
 For services, you can filter by technology type:
 
-- `--go-only`: Only update Go services (services with `docker_image_name: go_services`)
-- `--js-only`: Only update JS services (services with `docker_image_name` != `go_services`)
+- `--go-only`: Only update Go services (services with `docker_image_name: go_services` or `go-services`)
+- `--js-only`: Only update JS services (services with `docker_image_name` != `go_services`/`go-services`)
+
+**Note:** `_base.json` files are always updated regardless of filtering flags, as they are template/base configuration files that don't contain meaningful docker_image_name values for filtering.
 
 For example
 

--- a/cmd/cdep/README.md
+++ b/cmd/cdep/README.md
@@ -53,10 +53,19 @@ This command will find all services on the `master` branch and remove that from 
 
 `cdep update-default {type} {env|all}`
 
+#### Service Filtering
+
+For services, you can filter by technology type:
+
+- `--go-only`: Only update Go services (services with `docker_image_name: go_services`)
+- `--js-only`: Only update JS services (services with `docker_image_name` != `go_services`)
+
 For example
 
 - `cdep update-default lambdas avocado`
 - `cdep update-default services all`
+- `cdep update-default services avocado --go-only`
+- `cdep update-default services avocado --js-only`
 
 ## Common errors
 

--- a/tools/cdep/cdep.go
+++ b/tools/cdep/cdep.go
@@ -17,6 +17,7 @@ var ErrorCodeMapping = map[string]string{
 	"too_many_apps":             "You can only specify one application for web updates",
 	"web_deployment_not_found":  "The commit hash discovered has not been pushed to s3 yet",
 	"terraform_token_not_found": "No Terraform token found. Please generate one on Terraform (https://app.terraform.io/app/settings/tokens) and put it into the environment variable \"CUVVA_TERRAFORM_TOKEN\".",
+	"conflicting_flags":         "Cannot specify both --go-only and --js-only flags at the same time.",
 }
 
 var OverruleChecks = map[string]string{

--- a/tools/cdep/cdep.go
+++ b/tools/cdep/cdep.go
@@ -18,6 +18,7 @@ var ErrorCodeMapping = map[string]string{
 	"web_deployment_not_found":  "The commit hash discovered has not been pushed to s3 yet",
 	"terraform_token_not_found": "No Terraform token found. Please generate one on Terraform (https://app.terraform.io/app/settings/tokens) and put it into the environment variable \"CUVVA_TERRAFORM_TOKEN\".",
 	"conflicting_flags":         "Cannot specify both --go-only and --js-only flags at the same time.",
+	"missing_services":          "You must specify service names or use 'all' to update all services.",
 }
 
 var OverruleChecks = map[string]string{

--- a/tools/cdep/commands/update_default.go
+++ b/tools/cdep/commands/update_default.go
@@ -24,8 +24,8 @@ func init() {
 	UpdateDefaultCmd.Flags().StringSliceP("overrule-checks", "", []string{}, "Overrule checks the tool does")
 	UpdateDefaultCmd.Flags().StringP("message", "m", "", "More details about the deployment")
 	UpdateDefaultCmd.Flags().StringP("commit", "c", "", "Commit hash to use")
-	UpdateDefaultCmd.Flags().BoolP("go-only", "", false, "Only update Go services (docker_image_name: go_services)")
-	UpdateDefaultCmd.Flags().BoolP("js-only", "", false, "Only update JS services (docker_image_name != go_services)")
+	UpdateDefaultCmd.Flags().BoolP("go-only", "", false, "Only update Go services (docker_image_name: go_services or go-services)")
+	UpdateDefaultCmd.Flags().BoolP("js-only", "", false, "Only update JS services (docker_image_name != go_services/go-services)")
 
 	UpdateDefaultCmd.Flags().MarkHidden("overrule-checks")
 

--- a/tools/cdep/commands/update_default.go
+++ b/tools/cdep/commands/update_default.go
@@ -24,6 +24,8 @@ func init() {
 	UpdateDefaultCmd.Flags().StringSliceP("overrule-checks", "", []string{}, "Overrule checks the tool does")
 	UpdateDefaultCmd.Flags().StringP("message", "m", "", "More details about the deployment")
 	UpdateDefaultCmd.Flags().StringP("commit", "c", "", "Commit hash to use")
+	UpdateDefaultCmd.Flags().BoolP("go-only", "", false, "Only update Go services (docker_image_name: go_services)")
+	UpdateDefaultCmd.Flags().BoolP("js-only", "", false, "Only update JS services (docker_image_name != go_services)")
 
 	UpdateDefaultCmd.Flags().MarkHidden("overrule-checks")
 
@@ -44,6 +46,8 @@ var UpdateDefaultCmd = &cobra.Command{
 	Example: strings.Join([]string{
 		"update-default services avocado",
 		"update-default services avocado -c f1ec178befe6ed26ce9cec0aa419c763c203bc92",
+		"update-default services avocado --go-only",
+		"update-default services avocado --js-only",
 		"update-default lambda all",
 	}, "\n"),
 	Args: updateDefaultArgs,
@@ -68,6 +72,23 @@ var UpdateDefaultCmd = &cobra.Command{
 		commit, err := cmd.Flags().GetString("commit")
 		if err != nil {
 			return err
+		}
+
+		goOnly, err := cmd.Flags().GetBool("go-only")
+		if err != nil {
+			return err
+		}
+
+		jsOnly, err := cmd.Flags().GetBool("js-only")
+		if err != nil {
+			return err
+		}
+
+		// Validate that both flags are not set at the same time
+		if goOnly && jsOnly {
+			return cher.New("conflicting_flags", cher.M{
+				"message": "Cannot specify both --go-only and --js-only flags",
+			})
 		}
 
 		params, err := parsers.Parse(args, useProd)
@@ -102,7 +123,7 @@ var UpdateDefaultCmd = &cobra.Command{
 			return err
 		}
 
-		return a.UpdateDefault(ctx, params, overruleChecks)
+		return a.UpdateDefault(ctx, params, overruleChecks, goOnly, jsOnly)
 	},
 }
 

--- a/tools/cdep/helpers/docker_image.go
+++ b/tools/cdep/helpers/docker_image.go
@@ -1,0 +1,25 @@
+package helpers
+
+import (
+	"os"
+	"regexp"
+)
+
+// dockerImageNameRegex regex pattern to extract docker_image_name from service config files
+var dockerImageNameRegex = regexp.MustCompile(`"?docker_image_name"?\s*:\s*"?([a-zA-Z\d_-]+)"?`)
+
+// ExtractDockerImageName extracts the docker_image_name from a service configuration file.
+// Returns the docker image name, or an empty string if not found.
+func ExtractDockerImageName(filePath string) (string, error) {
+	fileContents, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+
+	matches := dockerImageNameRegex.FindSubmatch(fileContents)
+	if len(matches) != 2 {
+		return "", nil // Not found, but not an error
+	}
+
+	return string(matches[1]), nil
+}

--- a/tools/cdep/helpers/docker_image.go
+++ b/tools/cdep/helpers/docker_image.go
@@ -6,7 +6,8 @@ import (
 )
 
 // dockerImageNameRegex regex pattern to extract docker_image_name from service config files
-var dockerImageNameRegex = regexp.MustCompile(`"?docker_image_name"?\s*:\s*"?([a-zA-Z\d_-]+)"?`)
+// Handles both JSON and YAML formats with optional quotes (single or double)
+var dockerImageNameRegex = regexp.MustCompile(`["']?docker_image_name["']?\s*:\s*["']?([a-zA-Z\d_-]+)["']?`)
 
 // ExtractDockerImageName extracts the docker_image_name from a service configuration file.
 // Returns the docker image name, or an empty string if not found.

--- a/tools/cdep/helpers/docker_image_test.go
+++ b/tools/cdep/helpers/docker_image_test.go
@@ -1,0 +1,353 @@
+package helpers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExtractDockerImageName(t *testing.T) {
+	// Create a temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "cdep_test_*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	tests := []struct {
+		name           string
+		fileContent    string
+		expectedImage  string
+		expectedError  bool
+		description    string
+	}{
+		{
+			name: "go_services_json",
+			fileContent: `{
+	"docker_image_name": "go_services",
+	"branch": "master",
+	"commit": "abc123"
+}`,
+			expectedImage: "go_services",
+			expectedError: false,
+			description:   "Standard Go service JSON config",
+		},
+		{
+			name: "js_service_json",
+			fileContent: `{
+	"docker_image_name": "js_frontend",
+	"branch": "master",
+	"commit": "def456"
+}`,
+			expectedImage: "js_frontend",
+			expectedError: false,
+			description:   "Standard JS service JSON config",
+		},
+		{
+			name: "quoted_image_name",
+			fileContent: `{
+	"docker_image_name": "my-service-name",
+	"other_field": "value"
+}`,
+			expectedImage: "my-service-name",
+			expectedError: false,
+			description:   "Image name with hyphens in quotes",
+		},
+		{
+			name: "unquoted_image_name",
+			fileContent: `{
+	docker_image_name: my_service_123,
+	other_field: "value"
+}`,
+			expectedImage: "my_service_123",
+			expectedError: false,
+			description:   "Unquoted image name (YAML-style)",
+		},
+		{
+			name: "image_name_with_spaces",
+			fileContent: `{
+	"docker_image_name"  :  "spaced_service"  ,
+	"other_field": "value"
+}`,
+			expectedImage: "spaced_service",
+			expectedError: false,
+			description:   "Image name with extra spaces around colons",
+		},
+		{
+			name: "yaml_format",
+			fileContent: `docker_image_name: yaml_service
+branch: master
+commit: xyz789`,
+			expectedImage: "yaml_service",
+			expectedError: false,
+			description:   "YAML format configuration",
+		},
+		{
+			name: "yaml_quoted",
+			fileContent: `docker_image_name: "yaml_quoted_service"
+branch: "master"`,
+			expectedImage: "yaml_quoted_service",
+			expectedError: false,
+			description:   "YAML format with quoted values",
+		},
+		{
+			name: "no_docker_image_name",
+			fileContent: `{
+	"branch": "master",
+	"commit": "abc123",
+	"other_field": "value"
+}`,
+			expectedImage: "",
+			expectedError: false,
+			description:   "Config without docker_image_name field",
+		},
+		{
+			name: "empty_docker_image_name",
+			fileContent: `{
+	"docker_image_name": "",
+	"branch": "master"
+}`,
+			expectedImage: "",
+			expectedError: false,
+			description:   "Config with empty docker_image_name",
+		},
+		{
+			name: "multiple_occurrences",
+			fileContent: `{
+	"docker_image_name": "first_service",
+	"description": "This service uses docker_image_name for deployment",
+	"backup_docker_image_name": "backup_service"
+}`,
+			expectedImage: "first_service",
+			expectedError: false,
+			description:   "Multiple occurrences - should match first",
+		},
+		{
+			name: "malformed_json",
+			fileContent: `{
+	"docker_image_name": "service_name"
+	"missing_comma": "value"
+}`,
+			expectedImage: "service_name",
+			expectedError: false,
+			description:   "Malformed JSON but valid docker_image_name",
+		},
+		{
+			name: "nested_structure",
+			fileContent: `{
+	"config": {
+		"docker_image_name": "nested_service"
+	},
+	"docker_image_name": "top_level_service"
+}`,
+			expectedImage: "nested_service",
+			expectedError: false,
+			description:   "Nested structure - should match first occurrence",
+		},
+		{
+			name: "special_characters",
+			fileContent: `{
+	"docker_image_name": "service-with_special123",
+	"branch": "master"
+}`,
+			expectedImage: "service-with_special123",
+			expectedError: false,
+			description:   "Image name with allowed special characters",
+		},
+		{
+			name: "empty_file",
+			fileContent: "",
+			expectedImage: "",
+			expectedError: false,
+			description:   "Empty file",
+		},
+		{
+			name: "only_whitespace",
+			fileContent: "   \n\t  \n  ",
+			expectedImage: "",
+			expectedError: false,
+			description:   "File with only whitespace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test file
+			testFile := filepath.Join(tempDir, tt.name+".json")
+			err := os.WriteFile(testFile, []byte(tt.fileContent), 0644)
+			if err != nil {
+				t.Fatalf("Failed to create test file: %v", err)
+			}
+
+			// Test the function
+			result, err := ExtractDockerImageName(testFile)
+
+			// Check error expectation
+			if tt.expectedError && err == nil {
+				t.Errorf("Expected error but got none")
+			}
+			if !tt.expectedError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			// Check result
+			if result != tt.expectedImage {
+				t.Errorf("Expected image name '%s', got '%s'", tt.expectedImage, result)
+			}
+
+			t.Logf("✓ %s: Expected '%s', got '%s'", tt.description, tt.expectedImage, result)
+		})
+	}
+}
+
+func TestExtractDockerImageName_FileErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		filePath    string
+		description string
+	}{
+		{
+			name:        "non_existent_file",
+			filePath:    "/tmp/non_existent_file_12345.json",
+			description: "Non-existent file should return error",
+		},
+		{
+			name:        "empty_path",
+			filePath:    "",
+			description: "Empty file path should return error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ExtractDockerImageName(tt.filePath)
+
+			// Should return error
+			if err == nil {
+				t.Errorf("Expected error for %s but got none", tt.description)
+			}
+
+			// Result should be empty on error
+			if result != "" {
+				t.Errorf("Expected empty result on error, got '%s'", result)
+			}
+
+			t.Logf("✓ %s: Got expected error: %v", tt.description, err)
+		})
+	}
+}
+
+func TestExtractDockerImageName_EdgeCases(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "cdep_edge_test_*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	tests := []struct {
+		name          string
+		fileContent   string
+		expectedImage string
+		description   string
+	}{
+		{
+			name: "very_long_image_name",
+			fileContent: `{
+	"docker_image_name": "very_long_service_name_with_many_characters_and_numbers_123456789",
+	"branch": "master"
+}`,
+			expectedImage: "very_long_service_name_with_many_characters_and_numbers_123456789",
+			description:   "Very long image name",
+		},
+		{
+			name: "single_character_name",
+			fileContent: `{
+	"docker_image_name": "a",
+	"branch": "master"
+}`,
+			expectedImage: "a",
+			description:   "Single character image name",
+		},
+		{
+			name: "numbers_only",
+			fileContent: `{
+	"docker_image_name": "123456",
+	"branch": "master"
+}`,
+			expectedImage: "123456",
+			description:   "Numbers only image name",
+		},
+		{
+			name: "mixed_quotes",
+			fileContent: `{
+	"docker_image_name": 'mixed_quotes_service',
+	"branch": "master"
+}`,
+			expectedImage: "mixed_quotes_service",
+			description:   "Mixed quote styles around values",
+		},
+		{
+			name: "case_sensitivity",
+			fileContent: `{
+	"DOCKER_IMAGE_NAME": "uppercase_field",
+	"docker_image_name": "lowercase_field"
+}`,
+			expectedImage: "lowercase_field",
+			description:   "Case sensitivity - should match exact field name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testFile := filepath.Join(tempDir, tt.name+".json")
+			err := os.WriteFile(testFile, []byte(tt.fileContent), 0644)
+			if err != nil {
+				t.Fatalf("Failed to create test file: %v", err)
+			}
+
+			result, err := ExtractDockerImageName(testFile)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if result != tt.expectedImage {
+				t.Errorf("Expected image name '%s', got '%s'", tt.expectedImage, result)
+			}
+
+			t.Logf("✓ %s: Expected '%s', got '%s'", tt.description, tt.expectedImage, result)
+		})
+	}
+}
+
+// Benchmark test to ensure the function performs well
+func BenchmarkExtractDockerImageName(b *testing.B) {
+	tempDir, err := os.MkdirTemp("", "cdep_bench_*")
+	if err != nil {
+		b.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create a test file
+	testContent := `{
+	"docker_image_name": "benchmark_service",
+	"branch": "master",
+	"commit": "abc123",
+	"other_field": "value",
+	"nested": {
+		"field": "value"
+	}
+}`
+	testFile := filepath.Join(tempDir, "benchmark.json")
+	err = os.WriteFile(testFile, []byte(testContent), 0644)
+	if err != nil {
+		b.Fatalf("Failed to create test file: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := ExtractDockerImageName(testFile)
+		if err != nil {
+			b.Fatalf("Unexpected error: %v", err)
+		}
+	}
+}

--- a/tools/cdep/helpers/docker_image_test.go
+++ b/tools/cdep/helpers/docker_image_test.go
@@ -30,7 +30,18 @@ func TestExtractDockerImageName(t *testing.T) {
 }`,
 			expectedImage: "go_services",
 			expectedError: false,
-			description:   "Standard Go service JSON config",
+			description:   "Standard Go service JSON config (underscore)",
+		},
+		{
+			name: "go_services_hyphen_json",
+			fileContent: `{
+	"docker_image_name": "go-services",
+	"branch": "master",
+	"commit": "abc123"
+}`,
+			expectedImage: "go-services",
+			expectedError: false,
+			description:   "Standard Go service JSON config (hyphen)",
 		},
 		{
 			name: "js_service_json",
@@ -167,6 +178,17 @@ branch: "master"`,
 			expectedImage: "",
 			expectedError: false,
 			description:   "File with only whitespace",
+		},
+		{
+			name: "base_config_file",
+			fileContent: `{
+	"docker_image_name": "base_template_service",
+	"branch": "master",
+	"commit": "template123"
+}`,
+			expectedImage: "base_template_service",
+			expectedError: false,
+			description:   "Base configuration file (should extract image name but be filtered out at higher level)",
 		},
 	}
 

--- a/tools/cdep/parsers/parse.go
+++ b/tools/cdep/parsers/parse.go
@@ -44,20 +44,26 @@ func Parse(args []string, prodSys bool) (*Params, error) {
 	itemSet := []string{}
 
 	if len(args) > 2 {
-		for _, item := range args[2:] {
-			// if we're dealing with services
-			if t == "service" {
-				// if this service is not in the exception list
-				if _, ok := exceptions[item]; !ok {
-					// check for the prefix
-					if !strings.HasPrefix(item, "service-") {
-						// add it if it does not exist
-						item = fmt.Sprintf("%s%s", "service-", item)
+		// Handle "all" keyword for services
+		if len(args) == 3 && args[2] == "all" {
+			// Leave itemSet empty - this signals to update all services
+			// The Update method will handle discovering all services
+		} else {
+			for _, item := range args[2:] {
+				// if we're dealing with services
+				if t == "service" {
+					// if this service is not in the exception list
+					if _, ok := exceptions[item]; !ok {
+						// check for the prefix
+						if !strings.HasPrefix(item, "service-") {
+							// add it if it does not exist
+							item = fmt.Sprintf("%s%s", "service-", item)
+						}
 					}
 				}
-			}
 
-			itemSet = append(itemSet, item)
+				itemSet = append(itemSet, item)
+			}
 		}
 	}
 


### PR DESCRIPTION
This pull request enhances the `cdep` CLI tool by introducing new features for updating services, adding service filtering capabilities, and refactoring the codebase for better maintainability. The most notable changes include support for updating all services in an environment, new filtering options for Go and JS services, and the extraction of helper functions for improved code reuse.

### New Features and Enhancements:
* Added support for updating all services in an environment using the `all` keyword in the `update` and `update-default` commands. (`cmd/cdep/README.md` - [[1]](diffhunk://#diff-6c67454be4a8f2fd0cd191690487bc7e05171bb9be5a4da2055fbbf4d12dff64L16-R39) [[2]](diffhunk://#diff-6c67454be4a8f2fd0cd191690487bc7e05171bb9be5a4da2055fbbf4d12dff64R75-R89)
* Introduced `--go-only` and `--js-only` flags to filter services by technology type during updates. (`cmd/cdep/README.md` - [[1]](diffhunk://#diff-6c67454be4a8f2fd0cd191690487bc7e05171bb9be5a4da2055fbbf4d12dff64L16-R39) [[2]](diffhunk://#diff-6c67454be4a8f2fd0cd191690487bc7e05171bb9be5a4da2055fbbf4d12dff64R75-R89); `tools/cdep/commands/update.go` - [[3]](diffhunk://#diff-e48e36bd48480737d15165f6aeb413d9641fa65d04a3a84c5ba5a80c422710c6R28-R29) [[4]](diffhunk://#diff-e48e36bd48480737d15165f6aeb413d9641fa65d04a3a84c5ba5a80c422710c6R89-R105); `tools/cdep/commands/update_default.go` - [[5]](diffhunk://#diff-9a97fab07950b29387ab8c52276ee43912b04653b5aa62b4d8374517eeed0ce1R27-R28) [[6]](diffhunk://#diff-9a97fab07950b29387ab8c52276ee43912b04653b5aa62b4d8374517eeed0ce1R77-R93)

### Codebase Refactoring:
* Refactored the `Update` and `UpdateDefault` methods to include additional parameters for filtering (`goOnly` and `jsOnly`). (`tools/cdep/app/update.go` - [[1]](diffhunk://#diff-2c9d8054b223ea056ec5d3be1320492935dcb1acd1ee6edf371104aba9739d27R18-R26) [[2]](diffhunk://#diff-2c9d8054b223ea056ec5d3be1320492935dcb1acd1ee6edf371104aba9739d27R117-R124); `tools/cdep/app/update_default.go` - [[3]](diffhunk://#diff-aa1e066f173e86813715266acfc5bde40831921a3351817e1b2f3e08116671d4R14-R23) [[4]](diffhunk://#diff-aa1e066f173e86813715266acfc5bde40831921a3351817e1b2f3e08116671d4R122-R136)
* Extracted `ExtractDockerImageName` and `ShouldUpdateService` helper functions to `tools/cdep/helpers/docker_image.go` for reusability and cleaner logic. (`tools/cdep/helpers/docker_image.go` - [tools/cdep/helpers/docker_image.goR1-R61](diffhunk://#diff-13c108584d8ed45a017d50806c70724e4e13fb303efc16d6c1d85f6a67abeb31R1-R61))

### Validation and Error Handling:
* Added validation to ensure `--go-only` and `--js-only` flags cannot be used simultaneously, with appropriate error messaging. (`tools/cdep/commands/update.go` - [[1]](diffhunk://#diff-e48e36bd48480737d15165f6aeb413d9641fa65d04a3a84c5ba5a80c422710c6R89-R105); `tools/cdep/commands/update_default.go` - [[2]](diffhunk://#diff-9a97fab07950b29387ab8c52276ee43912b04653b5aa62b4d8374517eeed0ce1R77-R93)
* Enhanced error handling for missing services and conflicting flags, with user-friendly messages. (`tools/cdep/cdep.go` - [[1]](diffhunk://#diff-e2e7cf882eb0e8cf1b5a2fcfec305ec1c87f0c5bee162b9ec461afbf9d08198eR20-R21); `tools/cdep/commands/update.go` - [[2]](diffhunk://#diff-e48e36bd48480737d15165f6aeb413d9641fa65d04a3a84c5ba5a80c422710c6L144-R165)

### Miscellaneous Improvements:
* Updated documentation and examples in `README.md` to reflect the new features and usage patterns. (`cmd/cdep/README.md` - [[1]](diffhunk://#diff-6c67454be4a8f2fd0cd191690487bc7e05171bb9be5a4da2055fbbf4d12dff64L16-R39) [[2]](diffhunk://#diff-6c67454be4a8f2fd0cd191690487bc7e05171bb9be5a4da2055fbbf4d12dff64R75-R89)
* Improved service discovery logic to handle "all" services and apply filtering during updates. (`tools/cdep/app/update.go` - [[1]](diffhunk://#diff-2c9d8054b223ea056ec5d3be1320492935dcb1acd1ee6edf371104aba9739d27R117-R124) [[2]](diffhunk://#diff-2c9d8054b223ea056ec5d3be1320492935dcb1acd1ee6edf371104aba9739d27R289-R353)# Description

Allows us to specify the services to deploy by language. When updating all services, we always need to ensure there is a go build & a js build. This allows us to deploy all go services without needing a JS build & vice versa.

With the nature of our system, there are a lot of libs that are used across all go services. When we make a change in these libs, and we need to run it across all of our services, it's difficult to cdep each go/js service individually. It is easier for us to just deploy all go/js at once. 

Example
```
cdep update-default services avocado -c blah --go-only
cdep update-default services prod -c blah --js-only
cdep update service avocado all --go-only
cdep update service basil all --js-only
```