### PR TITLE
Add ptr.Equal function for comparing pointer values without reflect

### DIFF
--- a/lib/ptr/ptr.go
+++ b/lib/ptr/ptr.go
@@ -31,3 +31,13 @@ func Float64(v float64) *float64 {
 func Time(v time.Time) *time.Time {
 	return &v
 }
+
+// Equal returns true if the two parameters are both nil or are pointers to the same value. Provides a type-safe generic
+// alternative to reflect.DeepEqual that ensures both parameters are pointers to the same comparable type.
+func Equal[T comparable](a *T, b *T) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+
+	return *a == *b
+}

--- a/lib/ptr/ptr_test.go
+++ b/lib/ptr/ptr_test.go
@@ -1,0 +1,106 @@
+package ptr_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cuvva/cuvva-public-go/lib/ptr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPtr(t *testing.T) {
+	v := 42
+	p := ptr.Ptr(v)
+	assert.NotNil(t, p)
+	assert.Equal(t, v, *p)
+	assert.NotSame(t, &v, p)
+
+	s := "hello"
+	sp := ptr.Ptr(s)
+	assert.NotNil(t, sp)
+	assert.Equal(t, s, *sp)
+}
+
+func TestString(t *testing.T) {
+	v := "hello"
+	p := ptr.String(v)
+	assert.NotNil(t, p)
+	assert.Equal(t, v, *p)
+}
+
+func TestBool(t *testing.T) {
+	for _, v := range []bool{true, false} {
+		p := ptr.Bool(v)
+		assert.NotNil(t, p)
+		assert.Equal(t, v, *p)
+	}
+}
+
+func TestInt(t *testing.T) {
+	v := 7
+	p := ptr.Int(v)
+	assert.NotNil(t, p)
+	assert.Equal(t, v, *p)
+}
+
+func TestInt64(t *testing.T) {
+	v := int64(1234567890)
+	p := ptr.Int64(v)
+	assert.NotNil(t, p)
+	assert.Equal(t, v, *p)
+}
+
+func TestFloat64(t *testing.T) {
+	v := 3.14
+	p := ptr.Float64(v)
+	assert.NotNil(t, p)
+	assert.Equal(t, v, *p)
+}
+
+func TestTime(t *testing.T) {
+	v := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+	p := ptr.Time(v)
+	assert.NotNil(t, p)
+	assert.True(t, p.Equal(v))
+}
+
+func TestEqual(t *testing.T) {
+	t.Run("int pointers", func(t *testing.T) {
+		a := ptr.Int(1)
+		b := ptr.Int(1)
+		c := ptr.Int(2)
+
+		assert.True(t, ptr.Equal(a, b))
+		assert.True(t, ptr.Equal[int](nil, nil))
+		assert.False(t, ptr.Equal(a, c))
+		assert.False(t, ptr.Equal(a, nil))
+		assert.False(t, ptr.Equal(nil, b))
+	})
+
+	t.Run("string pointers", func(t *testing.T) {
+		a := ptr.String("hello")
+		b := ptr.String("hello")
+		c := ptr.String("world")
+
+		assert.True(t, ptr.Equal(a, b))
+		assert.True(t, ptr.Equal[int](nil, nil))
+		assert.False(t, ptr.Equal(a, c))
+		assert.False(t, ptr.Equal(a, nil))
+		assert.False(t, ptr.Equal(nil, b))
+	})
+
+	t.Run("struct pointers", func(t *testing.T) {
+		type person struct {
+			name string
+		}
+		a := ptr.Ptr(person{name: "John"})
+		b := ptr.Ptr(person{name: "John"})
+		c := ptr.Ptr(person{name: "Yoko"})
+
+		assert.True(t, ptr.Equal(a, b))
+		assert.False(t, ptr.Equal(a, c))
+		assert.True(t, ptr.Equal[int](nil, nil))
+		assert.False(t, ptr.Equal(a, nil))
+		assert.False(t, ptr.Equal(nil, b))
+	})
+}


### PR DESCRIPTION
# Description

This PR introduces a `ptr.Equal` function to make comparisons of pointer values more concise. Previously, comparing two pointers would require nil-checks or using `reflect.DeepEqual`.

This avoids using the `reflect` package and instead uses generics to ensure two variables are pointers to the same comparable type. That means built-in types , like int, string, bool are supported. Struct comparison is also supported, but non-nil values will be compared with `==` only, so may not be suitable in all cases e.g. if the struct contains pointers.