### PR TITLE
clog: add ns precision to log timestamps

### DIFF
--- a/lib/clog/clog.go
+++ b/lib/clog/clog.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/cuvva/cuvva-public-go/lib/cher"
 	"github.com/cuvva/cuvva-public-go/lib/servicecontext"
@@ -39,8 +40,6 @@ const (
 	// TimestampKey is the log entry key for the timestamp
 	TimestampKey = "_timestamp"
 )
-
-const RFC3339Milli = "2006-01-02T15:04:05.000Z07:00"
 
 // Config allows services to configure the logging format, level and storage options
 // for Logrus logging.
@@ -77,7 +76,7 @@ func (c Config) Configure(ctx context.Context) (log *logrus.Entry) {
 	switch c.Format {
 	case "json", "logstash":
 		log.Logger.Formatter = &logrus.JSONFormatter{
-			TimestampFormat: RFC3339Milli,
+			TimestampFormat: time.RFC3339Nano,
 			FieldMap: logrus.FieldMap{
 				logrus.FieldKeyLevel: LevelKey,
 				logrus.FieldKeyMsg:   MessageKey,

--- a/lib/clog/clog.go
+++ b/lib/clog/clog.go
@@ -40,6 +40,8 @@ const (
 	TimestampKey = "_timestamp"
 )
 
+const RFC3339Milli = "2006-01-02T15:04:05.000Z07:00"
+
 // Config allows services to configure the logging format, level and storage options
 // for Logrus logging.
 type Config struct {
@@ -75,6 +77,7 @@ func (c Config) Configure(ctx context.Context) (log *logrus.Entry) {
 	switch c.Format {
 	case "json", "logstash":
 		log.Logger.Formatter = &logrus.JSONFormatter{
+			TimestampFormat: RFC3339Milli,
 			FieldMap: logrus.FieldMap{
 				logrus.FieldKeyLevel: LevelKey,
 				logrus.FieldKeyMsg:   MessageKey,


### PR DESCRIPTION
## Summary
- Set nanosecond precision in the JSON formatter's `TimestampFormat`.
- `_timestamp` now has fixed 9-digit ns precision, making same-second events orderable.

[sc-77934](https://app.shortcut.com/cuvva/story/77934)

## Test plan
- [x] Run a service locally with `LOG_FORMAT=json` and confirm `_timestamp` includes `.NNN` ms.
- [x] Confirm downstream log ingestion still parses the timestamp correctly.