### PR TITLE
add ptr.Copy function for duplicating pointer values

### DIFF
--- a/lib/ptr/ptr.go
+++ b/lib/ptr/ptr.go
@@ -41,3 +41,15 @@ func Equal[T comparable](a *T, b *T) bool {
 
 	return *a == *b
 }
+
+// Copy returns nil if the given pointer is nil, otherwise it copies the pointed-to value into a new variable and
+// returns a pointer to that copy. This is useful when assigning pointer fields between structs so that mutating one
+// struct does not affect the other.
+func Copy[T any](v *T) *T {
+	if v == nil {
+		return nil
+	}
+
+	c := *v
+	return &c
+}

--- a/lib/ptr/ptr_test.go
+++ b/lib/ptr/ptr_test.go
@@ -104,3 +104,43 @@ func TestEqual(t *testing.T) {
 		assert.False(t, ptr.Equal(nil, b))
 	})
 }
+
+func TestCopy(t *testing.T) {
+	t.Run("nil returns nil", func(t *testing.T) {
+		assert.Nil(t, ptr.Copy[int](nil))
+	})
+
+	t.Run("copies the value into a new pointer", func(t *testing.T) {
+		v := 42
+		p := &v
+		c := ptr.Copy(p)
+
+		assert.NotNil(t, c)
+		assert.Equal(t, *p, *c)
+		assert.NotSame(t, p, c)
+	})
+
+	t.Run("mutating the copy does not affect the original", func(t *testing.T) {
+		v := "hello"
+		p := &v
+		c := ptr.Copy(p)
+
+		*c = "world"
+
+		assert.Equal(t, "hello", *p)
+		assert.Equal(t, "world", *c)
+	})
+
+	t.Run("struct values are duplicated", func(t *testing.T) {
+		type person struct {
+			name string
+		}
+		p := ptr.Ptr(person{name: "John"})
+		c := ptr.Copy(p)
+
+		c.name = "Yoko"
+
+		assert.Equal(t, "John", p.name)
+		assert.Equal(t, "Yoko", c.name)
+	})
+}


### PR DESCRIPTION
## Summary

[sc-79663]

This PR adds a new generic `Copy` function to the `ptr` package.

It's a straightforward utility: pass in a pointer, and if it's nil you get nil back. Otherwise, it copies the pointed-to value into a new variable and returns a pointer to that copy. Super handy when you're assigning pointer fields between structs and want to avoid accidental mutations affecting the original struct.

## Changes

- Added generic `Copy[T any]` function to `lib/ptr/ptr.go` with clear documentation
- Covers the nil case (returns nil) and copies the value independently
- Added comprehensive `TestCopy` in `lib/ptr/ptr_test.go` with 4 test cases:
  - Nil input returns nil
  - Copies the value into a distinct pointer (different memory address)
  - Mutating the copy doesn't affect the original (scalars)
  - Struct values are properly duplicated so field mutations stay independent

## Testing

All tests pass:
- `go test ./lib/ptr` confirms the new function works as expected
- Covers both scalar types (int, string) and struct types
- Verifies pointer independence and value isolation

## Notes for Reviewers

Pretty straightforward addition! The function is generic over any type (no comparable constraint needed), so it works with anything. FYI, it follows the same pattern as the existing functions in the pkg - simple, focused, well-tested.

The use case: if you're copying a struct with pointer fields and want to avoid sharing pointers between instances, just wrap the assignment with `ptr.Copy()`. Dead simple but saves a lot of defensive coding.

## Checklist

- [x] Code builds and all tests pass
- [x] Follows existing code style and patterns
- [x] Well-documented function with clear intent
- [x] Comprehensive test coverage (nil, scalars, structs, independence)
