### PR TITLE
feat(cdep): add agentcore deploy type with per-agent repo resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *.dylib
 
 # Built binaries
-cdep
+/cdep
 
 # Test binary, built with `go test -c`
 *.test

--- a/cmd/cdep/README.md
+++ b/cmd/cdep/README.md
@@ -15,6 +15,8 @@ This tool is designed to speed up quick day-to-day updates, and is not meant to 
 
 `cdep update {type} {env|all} {...services}`
 
+Supported types are `service`, `lambda`, `terra` and `agentcore`.
+
 For example:
 
 - `cdep u service avocado -b fix-it sms ltm email web-underwriter`
@@ -22,6 +24,31 @@ For example:
 - `cdep u lambda avocado -b fix-it marketing-consent stm-policy-sale`
 - `cdep u service prod ltm --prod`
 - `cdep u service avocado ltm -b fix-it`
+
+#### agentcore
+
+Agentcore config lives under the special `_system` environment (`{system}/_system/agentcore`),
+so it is always deployed against `_system` rather than a per-service environment. It also tracks
+the `main` branch by default instead of `master`, so `-b` is only needed to deploy another branch.
+
+Unlike services and lambdas (which build from the monorepo), each agent lives in its own repo.
+Every agentcore config file must therefore declare its source repo, and cdep resolves the latest
+commit for the requested branch from that repo — no local clone required:
+
+```json
+{
+	"repo": "git@github.com:example-org/example-agent.git",
+	"branch": "main",
+	"commit": "0000000000000000000000000000000000000000"
+}
+```
+
+- `cdep u agentcore _system my-agent other-agent` (each resolves its own repo's `main` tip)
+- `cdep u agentcore _system my-agent --prod`
+- `cdep u agentcore _system my-agent -b my-feature`
+- `cdep u agentcore _system my-agent -c <40-char-hash>` (pin one agent to a specific commit)
+
+Because each agent has its own repo, a pinned `-c` can only target a single agent at a time.
 
 Or with some flags
 

--- a/tools/cdep/app/agentcore.go
+++ b/tools/cdep/app/agentcore.go
@@ -1,0 +1,39 @@
+package app
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/cuvva/cuvva-public-go/lib/cher"
+)
+
+// agentcoreConfig captures the fields cdep reads from an agentcore config file.
+// The file itself is rewritten by AddToConfig's regex logic (not by
+// re-marshalling this struct), so any other fields are left untouched.
+type agentcoreConfig struct {
+	Repo string `json:"repo"`
+}
+
+// readAgentcoreRepo extracts the source repo declared in an agentcore config
+// file. Each agent lives in its own repo, so the repo is read per-file to
+// resolve that repo's latest commit rather than assuming the monorepo.
+func readAgentcoreRepo(path string) (string, error) {
+	blob, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	var cfg agentcoreConfig
+	if err := json.Unmarshal(blob, &cfg); err != nil {
+		return "", cher.New("invalid_agentcore_config", cher.M{
+			"path":  path,
+			"error": err.Error(),
+		})
+	}
+
+	if cfg.Repo == "" {
+		return "", cher.New("missing_agentcore_repo", cher.M{"path": path})
+	}
+
+	return cfg.Repo, nil
+}

--- a/tools/cdep/app/agentcore_test.go
+++ b/tools/cdep/app/agentcore_test.go
@@ -1,0 +1,83 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cuvva/cuvva-public-go/lib/cher"
+)
+
+func TestReadAgentcoreRepo(t *testing.T) {
+	dir := t.TempDir()
+
+	write := func(name, body string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	good := write("good.json", `{
+	"repo": "git@github.com:example-org/example-agent.git",
+	"branch": "main",
+	"commit": "0000000000000000000000000000000000000000"
+}`)
+	repo, err := readAgentcoreRepo(good)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo != "git@github.com:example-org/example-agent.git" {
+		t.Fatalf("repo = %q", repo)
+	}
+
+	missing := write("missing.json", `{"branch":"main","commit":"0000000000000000000000000000000000000000"}`)
+	if _, err := readAgentcoreRepo(missing); cher.Coerce(err).Code != "missing_agentcore_repo" {
+		t.Fatalf("expected missing_agentcore_repo, got %v", err)
+	}
+
+	invalid := write("invalid.json", `{not valid json`)
+	if _, err := readAgentcoreRepo(invalid); cher.Coerce(err).Code != "invalid_agentcore_config" {
+		t.Fatalf("expected invalid_agentcore_config, got %v", err)
+	}
+}
+
+// AddToConfig is shared with the other types; this asserts it behaves correctly
+// on an agentcore-shaped file (branch "main", 40-zero commit placeholder).
+func TestAddToConfigAgentcore(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "agent.json")
+	os.WriteFile(p, []byte("{\n\t\"repo\": \"git@github.com:example-org/example-agent.git\",\n\t\"branch\": \"main\",\n\t\"commit\": \"0000000000000000000000000000000000000000\",\n\t\"env\": {\n\t\t\"MODE\": \"a2a\"\n\t}\n}\n"), 0o644)
+
+	hash := "7fbcf728fe0682e62f3c5e179ebf2e846a99d3c2"
+	changed, err := App{}.AddToConfig(p, "main", hash)
+	if err != nil {
+		t.Fatalf("AddToConfig error: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+
+	out, _ := os.ReadFile(p)
+	s := string(out)
+	if !strings.Contains(s, `"commit": "`+hash+`"`) {
+		t.Fatalf("commit not updated:\n%s", s)
+	}
+	if !strings.Contains(s, `"branch": "main"`) {
+		t.Fatalf("branch not preserved:\n%s", s)
+	}
+	if !strings.Contains(s, `"MODE": "a2a"`) {
+		t.Fatalf("unrelated fields clobbered:\n%s", s)
+	}
+
+	// second run with the same values is a no-op
+	changed, err = App{}.AddToConfig(p, "main", hash)
+	if err != nil {
+		t.Fatalf("AddToConfig (rerun) error: %v", err)
+	}
+	if changed {
+		t.Fatal("expected no change on rerun")
+	}
+}

--- a/tools/cdep/app/update.go
+++ b/tools/cdep/app/update.go
@@ -29,7 +29,28 @@ func (a App) Update(ctx context.Context, req *parsers.Params, overruleChecks []s
 		return cher.New("invalid_operation", nil)
 	}
 
-	if req.Commit == "" {
+	// agentcore config only exists under the _system env, so reject anything else
+	// (including "all") up front rather than failing later with a confusing
+	// missing-file error while iterating per-service environments.
+	if req.Type == "agentcore" && req.Environment != "_system" {
+		return cher.New("agentcore_requires_system_env", nil)
+	}
+
+	// agentcore lives under the _system env, so it bypasses the env == "prod"
+	// guard above; enforce the default branch for prod agentcore deploys directly.
+	if req.Type == "agentcore" && req.System == "prod" && req.Branch != cdep.AgentcoreDefaultBranch {
+		return cher.New("invalid_operation", nil)
+	}
+
+	// A single explicit --commit cannot be applied across agentcore items, as
+	// each agent has its own source repo; deploy one agent at a time when pinning.
+	if req.Type == "agentcore" && req.Commit != "" && len(req.Items) > 1 {
+		return cher.New("commit_requires_single_agent", nil)
+	}
+
+	// agentcore items each declare their own source repo in their config, so the
+	// commit is resolved per-item below rather than once from the monorepo here.
+	if req.Commit == "" && req.Type != "agentcore" {
 		log.Info("getting latest commit hash")
 		latestHash, err := git.GetLatestCommitHash(ctx, req.Branch)
 		if err != nil {
@@ -40,8 +61,10 @@ func (a App) Update(ctx context.Context, req *parsers.Params, overruleChecks []s
 	}
 
 	// Validate commit hash is a full 40-character hash, not a short hash or branch name
-	if err := cdep.ValidateCommitHash(req.Commit); err != nil {
-		return err
+	if req.Commit != "" {
+		if err := cdep.ValidateCommitHash(req.Commit); err != nil {
+			return err
+		}
 	}
 
 	repoPath, err := paths.GetConfigRepo()
@@ -182,6 +205,49 @@ func (a App) Update(ctx context.Context, req *parsers.Params, overruleChecks []s
 
 				if changed {
 					shorthandPath := path.Join(req.System, env, "terra", workspace+".json")
+					updatedFiles = append(updatedFiles, shorthandPath)
+				}
+			}
+		case "agentcore":
+			for _, item := range req.Items {
+				p := paths.GetPathForAgentcore(repoPath, req.System, env, item)
+
+				// Warn and skip a missing/misnamed item rather than aborting the
+				// whole run; matches how AddToConfig tolerates missing files for
+				// the other types, and avoids readAgentcoreRepo hard-erroring below.
+				if _, err := os.Stat(p); err != nil {
+					log.Warn(err)
+					continue
+				}
+
+				// Each agent declares its own source repo, so resolve the latest
+				// commit from that repo unless one was pinned with --commit.
+				commit := req.Commit
+				if commit == "" {
+					repoURL, err := readAgentcoreRepo(p)
+					if err != nil {
+						return fmt.Errorf("read agentcore repo: %w", err)
+					}
+
+					log.Infof("resolving latest %s commit for %s from %s", req.Branch, item, repoURL)
+
+					commit, err = git.GetLatestCommitHashForRepo(ctx, repoURL, req.Branch)
+					if err != nil {
+						return fmt.Errorf("get agentcore commit: %w", err)
+					}
+
+					if err := cdep.ValidateCommitHash(commit); err != nil {
+						return err
+					}
+				}
+
+				changed, err := a.AddToConfig(p, req.Branch, commit)
+				if err != nil {
+					return err
+				}
+
+				if changed {
+					shorthandPath := path.Join(req.System, env, "agentcore", item+".json")
 					updatedFiles = append(updatedFiles, shorthandPath)
 				}
 			}

--- a/tools/cdep/app/update_test.go
+++ b/tools/cdep/app/update_test.go
@@ -1,0 +1,44 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cuvva/cuvva-public-go/lib/cher"
+	"github.com/cuvva/cuvva-public-go/tools/cdep/parsers"
+)
+
+// The agentcore guards sit at the top of Update and return before any
+// git/config/AWS work, so they can be exercised in isolation.
+func TestUpdateAgentcoreGuards(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *parsers.Params
+		want string
+	}{
+		{
+			name: "non-_system env rejected (incl. all)",
+			req:  &parsers.Params{Type: "agentcore", System: "nonprod", Environment: "all", Branch: "main", Items: []string{"a"}},
+			want: "agentcore_requires_system_env",
+		},
+		{
+			name: "pinned commit cannot span multiple agents",
+			req:  &parsers.Params{Type: "agentcore", System: "nonprod", Environment: "_system", Branch: "main", Commit: "7fbcf728fe0682e62f3c5e179ebf2e846a99d3c2", Items: []string{"a", "b"}},
+			want: "commit_requires_single_agent",
+		},
+		{
+			name: "prod agentcore must be on default branch",
+			req:  &parsers.Params{Type: "agentcore", System: "prod", Environment: "_system", Branch: "some-feature", Items: []string{"a"}},
+			want: "invalid_operation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := App{}.Update(context.Background(), tt.req, nil)
+			if code := cher.Coerce(err).Code; code != tt.want {
+				t.Fatalf("got %q, want %q (err: %v)", code, tt.want, err)
+			}
+		})
+	}
+}

--- a/tools/cdep/cdep.go
+++ b/tools/cdep/cdep.go
@@ -5,19 +5,26 @@ const Version = "0.6"
 // DefaultBranch is the default main branch
 const DefaultBranch = "master"
 
+// AgentcoreDefaultBranch is the default branch for agentcore deployments
+const AgentcoreDefaultBranch = "main"
+
 var ErrorCodeMapping = map[string]string{
-	"config_not_on_master":      "Your config repo is not on master, please swap your HEAD back to master.",
-	"frozen_without_commit":     "We found a resource where the config is locked, but no commit is specified.",
-	"frozen":                    "The resource you're trying to update is currently frozen.",
-	"nothing_changed":           "Running this tool has resulted in no change.",
-	"unknown_environment":       "You've provided an environment that does not exist in the provided system.",
-	"unknown_system":            "You've provided a system that does not exist.",
-	"unknown_type":              "You're trying to update something this tool cannot handle.",
-	"working_copy_dirty":        "Your config repo working copy is dirty, please clean it up and try again.",
-	"too_many_apps":             "You can only specify one application for web updates",
-	"web_deployment_not_found":  "The commit hash discovered has not been pushed to s3 yet",
-	"terraform_token_not_found": "No Terraform token found. Please generate one on Terraform (https://app.terraform.io/app/settings/tokens) and put it into the environment variable \"CUVVA_TERRAFORM_TOKEN\".",
-	"invalid_commit_hash":       "Commit hash must be exactly 40 hexadecimal characters. Short hashes and branch names are not allowed. Please provide the full commit hash.",
+	"config_not_on_master":          "Your config repo is not on master, please swap your HEAD back to master.",
+	"frozen_without_commit":         "We found a resource where the config is locked, but no commit is specified.",
+	"frozen":                        "The resource you're trying to update is currently frozen.",
+	"nothing_changed":               "Running this tool has resulted in no change.",
+	"unknown_environment":           "You've provided an environment that does not exist in the provided system.",
+	"unknown_system":                "You've provided a system that does not exist.",
+	"unknown_type":                  "You're trying to update something this tool cannot handle.",
+	"working_copy_dirty":            "Your config repo working copy is dirty, please clean it up and try again.",
+	"too_many_apps":                 "You can only specify one application for web updates",
+	"web_deployment_not_found":      "The commit hash discovered has not been pushed to s3 yet",
+	"terraform_token_not_found":     "No Terraform token found. Please generate one on Terraform (https://app.terraform.io/app/settings/tokens) and put it into the environment variable \"CUVVA_TERRAFORM_TOKEN\".",
+	"invalid_commit_hash":           "Commit hash must be exactly 40 hexadecimal characters. Short hashes and branch names are not allowed. Please provide the full commit hash.",
+	"missing_agentcore_repo":        "This agentcore config is missing a \"repo\" field. Add the agent's source repo (SSH URL) so cdep knows where to resolve the commit from.",
+	"invalid_agentcore_config":      "This agentcore config could not be parsed as JSON.",
+	"commit_requires_single_agent":  "A pinned --commit can only target one agentcore agent at a time, as each agent has its own source repo.",
+	"agentcore_requires_system_env": "agentcore config only exists under the \"_system\" env; use \"_system\" as the environment.",
 }
 
 var OverruleChecks = map[string]string{

--- a/tools/cdep/commands/update.go
+++ b/tools/cdep/commands/update.go
@@ -51,6 +51,7 @@ var UpdateCmd = &cobra.Command{
 		"update lambda basil ltm-proxy",
 		"update cloudfront prod website --prod",
 		"update terra avocado aws-env",
+		"update agentcore _system my-agent other-agent",
 	}, "\n"),
 	Aliases: []string{"u"},
 	Args:    updateArgs,
@@ -85,6 +86,12 @@ var UpdateCmd = &cobra.Command{
 		params, err := parsers.Parse(args, useProd)
 		if err != nil {
 			return err
+		}
+
+		// agentcore config tracks the "main" branch rather than "master";
+		// default to it unless the user explicitly passed -b.
+		if params.Type == "agentcore" && !cmd.Flags().Changed("branch") {
+			branch = cdep.AgentcoreDefaultBranch
 		}
 
 		params.Branch = branch

--- a/tools/cdep/git/remote.go
+++ b/tools/cdep/git/remote.go
@@ -1,0 +1,43 @@
+package git
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+
+	"github.com/cuvva/cuvva-public-go/lib/cher"
+)
+
+// GetLatestCommitHashForRepo returns the tip commit of branchName for an
+// arbitrary remote repo identified by repoURL, so each agentcore item can
+// resolve its own source repo dynamically. No local clone required.
+//
+// It shells out to `git ls-remote` (the same way cdep already runs config-repo
+// fetch/pull/push) rather than using go-git in-process, so it uses the caller's
+// normal git and SSH configuration — identity files, ssh agent, known_hosts —
+// instead of go-git's agent-only auth.
+func GetLatestCommitHashForRepo(ctx context.Context, repoURL, branchName string) (string, error) {
+	target := "refs/heads/" + branchName
+
+	out, err := exec.CommandContext(ctx, "git", "ls-remote", repoURL, target).Output()
+	if err != nil {
+		return "", cher.New("git_repo_error", cher.M{
+			"repo":  repoURL,
+			"error": err.Error(),
+		})
+	}
+
+	// Each line is "<hash>\t<ref>"; match the branch ref exactly rather than
+	// trusting ls-remote's loose pattern matching.
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[1] == target {
+			return fields[0], nil
+		}
+	}
+
+	return "", cher.New("remote_branch_not_found", cher.M{
+		"repo":   repoURL,
+		"branch": branchName,
+	})
+}

--- a/tools/cdep/git/remote.go
+++ b/tools/cdep/git/remote.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/cuvva/cuvva-public-go/lib/cher"
 )
+
+// lsRemoteTimeout bounds a single `git ls-remote` call so a network stall
+// against an agent's repo cannot hang the whole deploy indefinitely.
+const lsRemoteTimeout = 30 * time.Second
 
 // GetLatestCommitHashForRepo returns the tip commit of branchName for an
 // arbitrary remote repo identified by repoURL, so each agentcore item can
@@ -18,6 +23,9 @@ import (
 // instead of go-git's agent-only auth.
 func GetLatestCommitHashForRepo(ctx context.Context, repoURL, branchName string) (string, error) {
 	target := "refs/heads/" + branchName
+
+	ctx, cancel := context.WithTimeout(ctx, lsRemoteTimeout)
+	defer cancel()
 
 	out, err := exec.CommandContext(ctx, "git", "ls-remote", repoURL, target).Output()
 	if err != nil {

--- a/tools/cdep/git/remote_test.go
+++ b/tools/cdep/git/remote_test.go
@@ -1,0 +1,32 @@
+package git
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/cuvva/cuvva-public-go/lib/cher"
+)
+
+var hex40 = regexp.MustCompile(`^[a-f0-9]{40}$`)
+
+// Uses a public repo over HTTPS and skips when the network is unavailable, so
+// it never fails CI offline and never touches private infrastructure.
+func TestGetLatestCommitHashForRepo(t *testing.T) {
+	const repo = "https://github.com/go-git/go-git.git"
+
+	ctx := context.Background()
+
+	hash, err := GetLatestCommitHashForRepo(ctx, repo, "master")
+	if err != nil {
+		t.Skipf("network unavailable, skipping live ls-remote: %v", err)
+	}
+	if !hex40.MatchString(hash) {
+		t.Fatalf("expected 40-char hex hash, got %q", hash)
+	}
+
+	_, err = GetLatestCommitHashForRepo(ctx, repo, "definitely-not-a-real-branch-xyz")
+	if code := cher.Coerce(err).Code; code != "remote_branch_not_found" {
+		t.Fatalf("expected remote_branch_not_found, got %q (%v)", code, err)
+	}
+}

--- a/tools/cdep/paths/agentcore.go
+++ b/tools/cdep/paths/agentcore.go
@@ -1,0 +1,9 @@
+package paths
+
+import (
+	"path"
+)
+
+func GetPathForAgentcore(repo, system, env, item string) string {
+	return path.Join(repo, system, env, "agentcore", item+".json")
+}

--- a/tools/cdep/paths/agentcore_test.go
+++ b/tools/cdep/paths/agentcore_test.go
@@ -1,0 +1,12 @@
+package paths
+
+import "testing"
+
+func TestGetPathForAgentcore(t *testing.T) {
+	got := GetPathForAgentcore("/repo", "nonprod", "_system", "my-agent")
+	want := "/repo/nonprod/_system/agentcore/my-agent.json"
+
+	if got != want {
+		t.Fatalf("GetPathForAgentcore = %q, want %q", got, want)
+	}
+}

--- a/tools/cdep/types.go
+++ b/tools/cdep/types.go
@@ -8,11 +8,12 @@ import (
 )
 
 var Types = map[string]struct{}{
-	"lambda":   {},
-	"lambdas":  {},
-	"service":  {},
-	"services": {},
-	"terra":    {},
+	"lambda":    {},
+	"lambdas":   {},
+	"service":   {},
+	"services":  {},
+	"terra":     {},
+	"agentcore": {},
 }
 
 func ParseTypeArg(in string) (string, error) {
@@ -30,6 +31,8 @@ func ParseTypeArg(in string) (string, error) {
 		return "lambda", nil
 	case "terra":
 		return "terra", nil
+	case "agentcore":
+		return "agentcore", nil
 	default:
 		return "", cher.New("impossible", nil)
 	}

--- a/tools/cdep/types_test.go
+++ b/tools/cdep/types_test.go
@@ -4,6 +4,33 @@ import (
 	"testing"
 )
 
+func TestParseTypeArg(t *testing.T) {
+	cases := map[string]string{
+		"service":   "service",
+		"services":  "service",
+		"lambda":    "lambda",
+		"lambdas":   "lambda",
+		"terra":     "terra",
+		"agentcore": "agentcore",
+	}
+
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			got, err := ParseTypeArg(in)
+			if err != nil {
+				t.Fatalf("ParseTypeArg(%q) error: %v", in, err)
+			}
+			if got != want {
+				t.Fatalf("ParseTypeArg(%q) = %q, want %q", in, got, want)
+			}
+		})
+	}
+
+	if _, err := ParseTypeArg("nope"); err == nil {
+		t.Fatal("expected error for unknown type")
+	}
+}
+
 func TestValidateCommitHash(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## What

Adds a new `agentcore` deploy type to the `cdep` tool, alongside the existing `service`, `lambda` and `terra` types.

Unlike services and lambdas — which build from a single shared monorepo — each agent lives in its own source repo. So every `agentcore` config file declares its own repo in a `repo` field, and cdep resolves that repo's latest commit for the requested branch via `git ls-remote`. There is no local clone, and it uses the caller's normal git/SSH configuration rather than any in-process, agent-only auth.

## Details

- **Per-agent repo resolution** — each `agentcore` config declares its source repo (an SSH/HTTPS git URL) in a `repo` field; cdep reads it per file and resolves the branch tip with `git ls-remote`.
- **`_system`-only** — agentcore config lives under the special `_system` environment; any other environment (including `all`) is rejected up front with a clear error.
- **Defaults to `main`** — agentcore tracks the `main` branch by default instead of `master`, so `-b` is only needed to deploy another branch.
- **Guards:**
  - prod agentcore deploys are pinned to the default branch;
  - a pinned `--commit` can only target a single agent (one hash cannot span multiple repos);
  - missing/misnamed agent config files warn-and-skip rather than aborting the whole run.
- **`.gitignore`** — anchored the built-binary ignore rule to `/cdep` so new source files under `tools/cdep/` are no longer silently ignored.

## Testing

Adds unit tests covering type parsing, path building, repo-field extraction, the config rewrite, the update guards, and remote commit resolution.

```
go test ./tools/cdep/...
```
