### PR TITLE
ptr: [sc-81030] add generic Value helper

### DIFF
--- a/lib/ptr/ptr.go
+++ b/lib/ptr/ptr.go
@@ -53,3 +53,14 @@ func Copy[T any](v *T) *T {
 	c := *v
 	return &c
 }
+
+// Value returns the pointed-to value, or the zero value if the pointer is nil. Provides the symmetric counterpart to
+// Ptr for safely dereferencing optional values.
+func Value[T any](p *T) T {
+	if p == nil {
+		var zero T
+		return zero
+	}
+
+	return *p
+}

--- a/lib/ptr/ptr_test.go
+++ b/lib/ptr/ptr_test.go
@@ -144,3 +144,32 @@ func TestCopy(t *testing.T) {
 		assert.Equal(t, "Yoko", c.name)
 	})
 }
+
+func TestValue(t *testing.T) {
+	t.Run("nil int pointer returns zero value", func(t *testing.T) {
+		assert.Equal(t, 0, ptr.Value[int](nil))
+	})
+
+	t.Run("nil string pointer returns zero value", func(t *testing.T) {
+		assert.Equal(t, "", ptr.Value[string](nil))
+	})
+
+	t.Run("nil struct pointer returns zero value", func(t *testing.T) {
+		type person struct {
+			name string
+		}
+
+		assert.Equal(t, person{}, ptr.Value[person](nil))
+	})
+
+	t.Run("non-nil pointer returns the pointed-to value", func(t *testing.T) {
+		assert.Equal(t, 42, ptr.Value(ptr.Int(42)))
+		assert.Equal(t, "hello", ptr.Value(ptr.String("hello")))
+
+		type person struct {
+			name string
+		}
+		p := ptr.Ptr(person{name: "John"})
+		assert.Equal(t, person{name: "John"}, ptr.Value(p))
+	})
+}


### PR DESCRIPTION
[[sc-81030]](https://app.shortcut.com/cuvva/story/81030)

Adds `Value[T]` to `lib/ptr` as the symmetric counterpart to `Ptr[T]` — it dereferences a pointer, returning the zero value when the pointer is nil.

Needed so the cuvva monorepo can migrate off `github.com/aws/smithy-go/ptr` (its `ptr.ToInt` has no cuvva equivalent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)