### PR TITLE
fix(cdep): allow slashes in branch names for YAML config

### DIFF
--- a/tools/cdep/app/add_config.go
+++ b/tools/cdep/app/add_config.go
@@ -19,7 +19,13 @@ var imageTagRegAdd = regexp.MustCompile(`"tag"\s*:\s*"([^"]+)"`)
 
 var commitRegAddYaml = regexp.MustCompile(`commit\s*:\s*"?[a-f\d]{40}"?`)
 var imageTagRegAddYaml = regexp.MustCompile(`tag\s*:\s*"?[a-z\d-]+"?`)
-var branchRegAddYaml = regexp.MustCompile(`branch\s*:\s*"?([a-zA-Z\d-._]+)"?`)
+
+// branchRegAddYaml must match the same branch names git allows, which include
+// path separators (e.g. "claude/my-feature"). The character class therefore
+// permits "/" and "\" as well as the usual identifier characters; omitting them
+// truncated slashed branches to their first segment (e.g. "claude"), leaving the
+// wrong branch in config and corrupting the value on redeploy.
+var branchRegAddYaml = regexp.MustCompile(`branch\s*:\s*"?([a-zA-Z\d._/\\-]+)"?`)
 
 var jsonExtraCommaCheck = regexp.MustCompile(`,\s*}`)
 

--- a/tools/cdep/app/add_config_test.go
+++ b/tools/cdep/app/add_config_test.go
@@ -1,0 +1,108 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// AddToConfig rewrites the branch value in a service's JSON or YAML config.
+// These tests cover the two branch shapes cdep sees in practice: the common
+// ticket-style names (e.g. "sc-1234-fix-thing", which must keep working) and
+// path-separated names (e.g. "claude/my-feature", which used to be truncated at
+// the first "/" in YAML configs, leaving the wrong branch and corrupting the
+// value on redeploy).
+func TestAddToConfigBranchNames(t *testing.T) {
+	const commit = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	tests := []struct {
+		name    string
+		file    string
+		initial string
+		branch  string
+		want    string // exact branch line/token expected in the output
+	}{
+		{
+			name:    "json ticket-style branch over master",
+			file:    "service.json",
+			initial: "{\n\t\"branch\": \"master\",\n\t\"commit\": \"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"\n}\n",
+			branch:  "sc-1234-fix-thing",
+			want:    "\"branch\": \"sc-1234-fix-thing\"",
+		},
+		{
+			name:    "yaml ticket-style branch over master",
+			file:    "service.yaml",
+			initial: "branch: master\ncommit: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n",
+			branch:  "sc-1234-fix-thing",
+			want:    "branch: sc-1234-fix-thing",
+		},
+		{
+			name:    "yaml redeploy same ticket-style branch",
+			file:    "service.yaml",
+			initial: "branch: sc-1234-fix-thing\ncommit: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n",
+			branch:  "sc-1234-fix-thing",
+			want:    "branch: sc-1234-fix-thing",
+		},
+		{
+			name:    "yaml dotted branch over master",
+			file:    "service.yaml",
+			initial: "branch: master\ncommit: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n",
+			branch:  "release-1.2.3",
+			want:    "branch: release-1.2.3",
+		},
+		{
+			name:    "json slashed branch over master",
+			file:    "service.json",
+			initial: "{\n\t\"branch\": \"master\",\n\t\"commit\": \"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"\n}\n",
+			branch:  "claude/cdep-branch-name-slashes",
+			want:    "\"branch\": \"claude/cdep-branch-name-slashes\"",
+		},
+		{
+			name:    "yaml slashed branch over master",
+			file:    "service.yaml",
+			initial: "branch: master\ncommit: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n",
+			branch:  "claude/cdep-branch-name-slashes",
+			want:    "branch: claude/cdep-branch-name-slashes",
+		},
+		{
+			name:    "yaml redeploy same slashed branch is not corrupted",
+			file:    "service.yaml",
+			initial: "branch: claude/cdep-branch-name-slashes\ncommit: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n",
+			branch:  "claude/cdep-branch-name-slashes",
+			want:    "branch: claude/cdep-branch-name-slashes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), tt.file)
+			if err := os.WriteFile(path, []byte(tt.initial), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := (App{}).AddToConfig(path, tt.branch, commit); err != nil {
+				t.Fatalf("AddToConfig: %v", err)
+			}
+
+			out, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := string(out)
+
+			if !strings.Contains(got, tt.want) {
+				t.Fatalf("config missing %q\n---\n%s", tt.want, got)
+			}
+			// Guard against the truncation/corruption bug: the branch must not
+			// gain a stray trailing segment (e.g. "claude/foo" -> "claude/foo/…").
+			if strings.Contains(got, tt.branch+"/") {
+				t.Fatalf("branch value %q was corrupted:\n%s", tt.branch, got)
+			}
+			// The old default must be gone once a feature branch is written.
+			if strings.Contains(got, "master") {
+				t.Fatalf("stale master branch left in config:\n%s", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

cdep couldn't deploy branches containing `/` (e.g. `claude/my-feature`) to nonprod. The branch name would be truncated to its first segment, leaving branches called just `claude` or `speckit` in nonprod environments.

## Root cause

cdep rewrites the `branch` value in each service's config file via regex in [`tools/cdep/app/add_config.go`](https://github.com/cuvva/cuvva-public-go/blob/master/tools/cdep/app/add_config.go). The **YAML** branch regex used a character class that excluded the path separator:

```go
var branchRegAddYaml = regexp.MustCompile(`branch\s*:\s*"?([a-zA-Z\d-._]+)"?`)
```

This truncates at the first `/`. Two concrete failure modes (both confirmed with a regex repro):

- **Corruption on redeploy** — a YAML config already at `branch: claude/foo`, redeployed to `claude/bar`, becomes `branch: claude/bar/foo` (only the `claude` segment gets replaced).
- **Wrong override prompt** — the current branch reads back as just `claude`, so cdep thinks the branch changed and prompts to override even when it hasn't.

The JSON path (`"branch"\s*:\s*"([^"]+)"`) already used `[^"]+` and handled slashes correctly.

## Notable changes

- Broadened `branchRegAddYaml` to permit `/` and `\`, matching what git allows in ref names, with a comment explaining why.
- Added `tools/cdep/app/add_config_test.go` covering both branch shapes in JSON and YAML: ordinary ticket-style names (hyphens/dots, no slash) as a regression guard, and slashed names including a redeploy-doesn't-corrupt case.

## QA

- `go test ./tools/cdep/...` — passes
- `go vet ./tools/cdep/...` and `go build ./tools/cdep/... ./cmd/cdep/...` — clean

## Notes for reviewer

The `/` case is the load-bearing fix. Backslash (`\`) is included in the class defensively, but git itself doesn't accept `\` in ref names, so forward slash is what matters in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)