### PR TITLE
Add Cuvvy review + tag workflows

### DIFF
--- a/.github/workflows/cuvvy-review.yml
+++ b/.github/workflows/cuvvy-review.yml
@@ -1,0 +1,17 @@
+# Place this in cuvva-public-go at .github/workflows/cuvvy-review.yml
+#
+# Calls the centrally managed Cuvvy review workflow. Repo-specific config is
+# auto-detected from github.repository (repos/cuvva-public-go/ in gha-cuvvy-workflows).
+
+name: Cuvvy Review
+
+on:
+  pull_request:
+    types:
+      - review_requested
+      - opened
+
+jobs:
+  auto-review:
+    uses: cuvva/gha-cuvvy-workflows/.github/workflows/cuvvy-review.yml@main
+    secrets: inherit

--- a/.github/workflows/cuvvy-tag.yml
+++ b/.github/workflows/cuvvy-tag.yml
@@ -1,0 +1,22 @@
+# Place this in cuvva-public-go at .github/workflows/cuvvy-tag.yml
+#
+# Calls the centrally managed Cuvvy interactive chat workflow. Responds to
+# @cuvvy mentions on issues, PRs, and reviews. Repo-specific config is
+# auto-detected from github.repository.
+
+name: Cuvvy Tag
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned, labeled]
+
+jobs:
+  claude-chat-action:
+    uses: cuvva/gha-cuvvy-workflows/.github/workflows/cuvvy-tag.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Description

Enables **Cuvvy** on this repo — automated PR review and `@cuvvy` interactive chat — by calling the centrally managed reusable workflows in `cuvva/gha-cuvvy-workflows`. Repo-specific config (a public-Go-library review command, tuned for API stability, `cher` error contracts, and no secrets/PII in a public repo) lives centrally and is auto-detected from `github.repository`.

Paired with cuvva/gha-cuvvy-workflows#107, which adds the `repos/cuvva-public-go/` config.

## Notable changes

- `.github/workflows/cuvvy-review.yml` — runs a Cuvvy review on PR open / review requested
- `.github/workflows/cuvvy-tag.yml` — responds to `@cuvvy` mentions on issues, PRs, and reviews

Both are zero-config (`secrets: inherit`); the default branch (`master`) is auto-detected.

## QA / before merging

- ⚠️ **This is a public repo.** Secrets passed via `secrets: inherit` are only available to public-repo workflows if the org explicitly allows it (Settings → Actions → "Send secrets to workflows in public repositories", or repo-scoped secret access). If that's off, runs will fail on missing credentials (AWS/Bedrock, Shortcut, etc.). Confirm with whoever manages org Actions settings before relying on it.
- Merge order: this can merge independently, but Cuvvy won't have repo-specific config until cuvva/gha-cuvvy-workflows#107 lands (it falls back to base config until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)